### PR TITLE
KP-5793 Make the workflow compatible with Rahti

### DIFF
--- a/.github/workflows/unit-test-python.yml
+++ b/.github/workflows/unit-test-python.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  unit-test:
     runs-on: self-hosted
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/unit-test-python.yml
+++ b/.github/workflows/unit-test-python.yml
@@ -18,8 +18,6 @@ jobs:
     runs-on: self-hosted
     steps:
     - uses: actions/checkout@v3
-    - name: Install Python 3.6
-      run: yum install python3 pip3 -y
     - name: Install required Python packages
       run: pip3 install -r requirements_dev.txt
     - name: Test with pytest

--- a/.github/workflows/unit-test-python.yml
+++ b/.github/workflows/unit-test-python.yml
@@ -19,6 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install required Python packages
-      run: pip3 install -r requirements_dev.txt
+      run: pip3 install -r requirements_dev.txt --user
     - name: Test with pytest
       run: python3 -m pytest


### PR DESCRIPTION
This required removing installations using yum, as we don't have root access. Installing python3 and pip3 are now done when preparing the container image instead.