### PR TITLE
KP-6162 Implement downloading of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# NFL Data Harvester
+# NLF Data Harvester
 This tool allows fetching data from the National Library of Finland. This tool
-interacts with the OAI-PMH API of NFL, fetching information about the available
+interacts with the OAI-PMH API of NLF, fetching information about the available
 bindings, downloading them and checking their integrity.
 
 ## Getting Started

--- a/harvester/file.py
+++ b/harvester/file.py
@@ -3,6 +3,10 @@ Representation of a single file (e.g. an XML file with OCR results for a
 page from a newspaper, or a jpeg showing the scanned page).
 """
 
+import os
+from pathlib import Path
+import urllib.request
+
 
 class File:
     """
@@ -63,6 +67,59 @@ class File:
         raise NotImplementedError(
             "download_url must be defined separately for each subclass of File"
         )
+
+    def _default_base_path(self):
+        """
+        TODO
+        """
+        return Path(os.getcwd())
+
+    def _default_file_dir(self, dc_identifier):
+        """
+        TODO
+        """
+        raise NotImplementedError("todo")  # TODO better msg, implement in subclasses
+
+    def _default_file_name(self):
+        """
+        TODO
+        """
+        raise NotImplementedError("todo")  # TODO better msg, implement in subclasses
+
+    def _construct_download_location(self, base_path, file_dir, file_name):
+        """
+        Return :class:`pathlib.Path`
+        """
+        if not base_path:
+            base_path = self._default_base_path
+        if not file_dir:
+            file_dir = self._default_file_dir
+        if not file_name:
+            file_name = self._default_file_name
+
+        return Path(base_path) / Path(file_dir) / Path(file_name)
+
+    def download(self, dc_identifier, base_path=None, file_dir=None, file_name=None):
+        """
+        Download the file from NLF.
+
+        :param dc_identifier: Dublin Core identifier for the binding to which this file
+            belongs. These identifiers are of form
+            https://digi.kansalliskirjasto.fi/sanomalehti/binding/[BINDING ID] and thus
+            the base of the download URL.
+        :type dc_identifier: String
+        :param base_path:
+        :type base_path:
+        :param file_dir:
+        :type file_dir:
+        :param file_name:
+        :type file_name:
+        """
+        output = self._construct_download_location(base_path, file_dir, file_name)
+        with urllib.request.urlopen(self.download_url(dc_identifier)) as source, open(
+            output, "w"
+        ) as output_file:
+            output_file.write(source.read())
 
 
 class UnknownTypeFile(File):

--- a/harvester/file.py
+++ b/harvester/file.py
@@ -5,7 +5,9 @@ page from a newspaper, or a jpeg showing the scanned page).
 
 import os
 from pathlib import Path
-import urllib.request
+import requests
+
+from harvester import utils
 
 
 class File:
@@ -13,7 +15,7 @@ class File:
     A shared base class for files originating from NLF.
     """
 
-    def __init__(self, checksum, algorithm, location_xlink):
+    def __init__(self, checksum, algorithm, location_xlink, binding_dc_identifier):
         """
         Create a new file
 
@@ -29,9 +31,21 @@ class File:
         self.checksum = checksum
         self.algorithm = algorithm
         self.location_xlink = location_xlink
+        self.binding_dc_identifier = binding_dc_identifier
+
+    @property
+    def filename(self):
+        """
+        Name of the file as reported in ``self.location_xlink``
+
+        :return: File name part of ``self.location_xlink``
+        :rtype: str
+        """
+        path_without_scheme = self.location_xlink.split("://")[-1]
+        return Path(path_without_scheme).name
 
     @classmethod
-    def file_from_element(cls, file_element):
+    def file_from_element(cls, file_element, binding_dc_identifier):
         """
         Return new subclass object representing the given file element.
 
@@ -52,9 +66,11 @@ class File:
             checksum=file_element.attrib["CHECKSUM"],
             algorithm=file_element.attrib["CHECKSUMTYPE"],
             location_xlink=location,
+            binding_dc_identifier=binding_dc_identifier,
         )
 
-    def download_url(self, dc_identifier):
+    @property
+    def download_url(self):
         """
         The URL from which this file can be downloaded from NLF.
 
@@ -70,56 +86,85 @@ class File:
 
     def _default_base_path(self):
         """
-        TODO
-        """
-        return Path(os.getcwd())
+        The default root directory for the file structure for downloaded bindings.
 
-    def _default_file_dir(self, dc_identifier):
+        :return: Path to the root of the file structure created for downloaded files.
+            Defaults to the current directory.
+        :rtype: :class:`pathlib.Path`
         """
-        TODO
-        """
-        raise NotImplementedError("todo")  # TODO better msg, implement in subclasses
+        return Path(os.getcwd()) / "downloads"
 
-    def _default_file_name(self):
+    def _default_file_dir(self):
         """
-        TODO
-        """
-        raise NotImplementedError("todo")  # TODO better msg, implement in subclasses
+        The default subdirectory (structure) for the downloaded files of this type.
 
-    def _construct_download_location(self, base_path, file_dir, file_name):
+        :return: The relative Path for the directory in which the downloaded files of
+            this type are placed under the base path.
+        :rtype: :class:`pathlib.Path`
+        """
+        raise NotImplementedError(
+            "Default file directory must be set on a per filetype basis"
+        )
+
+    def _default_filename(self):
+        """
+        The default file name for downloaded files.
+
+        :return: File name as a Path object
+        :rtype: :class:`pathlib.Path`
+        """
+        return self.filename
+
+    def _construct_download_location(self, base_path, file_dir, filename):
         """
         Return :class:`pathlib.Path`
         """
         if not base_path:
-            base_path = self._default_base_path
+            base_path = self._default_base_path()
         if not file_dir:
-            file_dir = self._default_file_dir
-        if not file_name:
-            file_name = self._default_file_name
+            file_dir = self._default_file_dir()
+        if not filename:
+            filename = self._default_filename()
 
-        return Path(base_path) / Path(file_dir) / Path(file_name)
+        return Path(base_path) / Path(file_dir) / Path(filename)
 
-    def download(self, dc_identifier, base_path=None, file_dir=None, file_name=None):
+    def _ensure_dir(self, dir_):
+        """
+        Make sure that the output directory exists
+        """
+
+    def download(self, base_path=None, file_dir=None, filename=None):
         """
         Download the file from NLF.
+
+        The output location can be specified with the components ``base_path``,
+        ``file_dir`` and ``filename``. If not given, the output location is as
+        follows::
+
+         ./downloads/[binding ID]/[type directory]/[filename from location_xlink]
+         ^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          base_path          file_dir                         filename
 
         :param dc_identifier: Dublin Core identifier for the binding to which this file
             belongs. These identifiers are of form
             https://digi.kansalliskirjasto.fi/sanomalehti/binding/[BINDING ID] and thus
             the base of the download URL.
-        :type dc_identifier: String
-        :param base_path:
-        :type base_path:
-        :param file_dir:
-        :type file_dir:
-        :param file_name:
-        :type file_name:
+        :type dc_identifier: str
+        :param base_path: The root directory for the file structure for
+            downloaded bindings.
+        :type base_path: str, optional
+        :param file_dir: Output directory for the files, relative to ``base_path``
+        :type file_dir: str, optional
+        :param filename: Output file name.
+        :type filename: str, optional
         """
-        output = self._construct_download_location(base_path, file_dir, file_name)
-        with urllib.request.urlopen(self.download_url(dc_identifier)) as source, open(
-            output, "w"
+        output = self._construct_download_location(base_path, file_dir, filename)
+        output.parent.mkdir(parents=True, exist_ok=True)
+
+        with requests.get(self.download_url, timeout=5) as source, open(
+            output, "wb"
         ) as output_file:
-            output_file.write(source.read())
+            output_file.write(source.content)
 
 
 class UnknownTypeFile(File):
@@ -135,7 +180,8 @@ class ALTOFile(File):
     An XML file with contents of a page described using the ALTO schema.
     """
 
-    def download_url(self, dc_identifier):
+    @property
+    def download_url(self):
         """
         The URL from which this file can be downloaded from NLF.
 
@@ -148,7 +194,17 @@ class ALTOFile(File):
         :type dc_identifier: String
         """
         href_filename = self.location_xlink.rsplit("/", maxsplit=1)[-1]
-        return f"{dc_identifier}/page-{href_filename}"
+        return f"{self.binding_dc_identifier}/page-{href_filename}"
+
+    def _default_file_dir(self):
+        """
+        The default subdirectory (structure) for the downloaded files of this type.
+
+        :return: The relative Path for the directory in which the downloaded files of
+            this type are placed under the base path.
+        :rtype: :class:`pathlib.Path`
+        """
+        return Path(utils.binding_id_from_dc(self.binding_dc_identifier)) / "alto"
 
 
 class METSLocationParseError(ValueError):

--- a/harvester/file.py
+++ b/harvester/file.py
@@ -164,6 +164,7 @@ class File:
         with requests.get(self.download_url, timeout=5) as source, open(
             output, "wb"
         ) as output_file:
+            source.raise_for_status()
             output_file.write(source.content)
 
 

--- a/harvester/file.py
+++ b/harvester/file.py
@@ -50,6 +50,20 @@ class File:
             location_xlink=location,
         )
 
+    def download_url(self, dc_identifier):
+        """
+        The URL from which this file can be downloaded from NLF.
+
+        :param dc_identifier: Dublin Core identifier for the binding to which this file
+            belongs. These identifiers are of form
+            https://digi.kansalliskirjasto.fi/sanomalehti/binding/[BINDING ID] and thus
+            the base of the download URL.
+        :type dc_identifier: String
+        """
+        raise NotImplementedError(
+            "download_url must be defined separately for each subclass of File"
+        )
+
 
 class UnknownTypeFile(File):
     """
@@ -63,6 +77,21 @@ class ALTOFile(File):
     """
     An XML file with contents of a page described using the ALTO schema.
     """
+
+    def download_url(self, dc_identifier):
+        """
+        The URL from which this file can be downloaded from NLF.
+
+        :param dc_identifier: Dublin Core identifier for the binding to which this file
+            belongs. These identifiers are of form
+            https://digi.kansalliskirjasto.fi/sanomalehti/binding/[BINDING ID] and thus
+            the base of the download URL. Note that this functionality relies on the
+            identifier not having a trailing slash (as seems to be the case in NLF
+            data).
+        :type dc_identifier: String
+        """
+        href_filename = self.location_xlink.rsplit("/", maxsplit=1)[-1]
+        return f"{dc_identifier}/page-{href_filename}"
 
 
 class METSLocationParseError(ValueError):

--- a/harvester/mets.py
+++ b/harvester/mets.py
@@ -20,7 +20,7 @@ class METS:
     # This is expected to change when the software develops
     # pylint: disable=too-few-public-methods
 
-    def __init__(self, mets_path, encoding="utf-8"):
+    def __init__(self, mets_path, binding_dc_identifier, encoding="utf-8"):
         """
         Create a new METS file object.
 
@@ -29,6 +29,7 @@ class METS:
         """
         self.mets_path = mets_path
         self.encoding = encoding
+        self.binding_dc_identifier = binding_dc_identifier
         self._files = None
 
     def _file_location(self, file_element):
@@ -59,7 +60,12 @@ class METS:
 
         self._files = []
         for file_element in files:
-            self._files.append(File.file_from_element(file_element))
+            self._files.append(
+                File.file_from_element(
+                    file_element,
+                    self.binding_dc_identifier,
+                )
+            )
 
     def files(self):
         """

--- a/harvester/mets.py
+++ b/harvester/mets.py
@@ -42,10 +42,6 @@ class METS:
         :raises METSLocationParseError: Raised if the location cannot be
                 determined, e.g. too many locations.
         """
-        children = file_element.getchildren()
-        if len(children) != 1:
-            raise METSLocationParseError("Expected 1 location, found {len(children)}")
-        return children[0].attrib["{http://www.w3.org/TR/xlink}href"]
 
     def _ensure_files(self):
         """
@@ -63,14 +59,7 @@ class METS:
 
         self._files = []
         for file_element in files:
-            self._files.append(
-                File(
-                    checksum=file_element.attrib["CHECKSUM"],
-                    algorithm=file_element.attrib["CHECKSUMTYPE"],
-                    location_xlink=self._file_location(file_element),
-                    content_type=None,
-                )
-            )
+            self._files.append(File.file_from_element(file_element))
 
     def files(self):
         """
@@ -82,9 +71,3 @@ class METS:
         self._ensure_files()
         for file in self._files:
             yield file
-
-
-class METSLocationParseError(ValueError):
-    """
-    Exception raised when location of a file cannot be determined.
-    """

--- a/harvester/pmh_interface.py
+++ b/harvester/pmh_interface.py
@@ -44,7 +44,7 @@ class PMH_API:
         """
 
         mets_url = f"{dc_identifier}/mets.xml?full=true"
-        xml_response = requests.get(mets_url)
+        xml_response = requests.get(mets_url, timeout=5)
 
         if not file_name:
             path = f"{folder_path}/{utils.binding_id_from_dc(dc_identifier)}_METS.xml"

--- a/harvester/pmh_interface.py
+++ b/harvester/pmh_interface.py
@@ -5,6 +5,8 @@ Fetch data from an OAI-PMH API of the National Library of Finland
 from sickle import Sickle
 import requests
 
+from harvester import utils
+
 
 class PMH_API:
     """
@@ -31,14 +33,6 @@ class PMH_API:
         for record in records:
             yield record.metadata["identifier"][0]
 
-    def binding_id_from_dc(self, dc_identifier):
-        """
-        Parse binding ID from dc_identifier URL.
-
-        :param dc_identifier: DC identifier of a record
-        """
-        return dc_identifier.split("/")[-1]
-
     def fetch_mets(self, dc_identifier, folder_path, file_name=None):
         """
         Fetch METS as an XML document given a binding ID and save to disk.
@@ -53,7 +47,7 @@ class PMH_API:
         xml_response = requests.get(mets_url)
 
         if not file_name:
-            path = f"{folder_path}/{self.binding_id_from_dc(dc_identifier)}_METS.xml"
+            path = f"{folder_path}/{utils.binding_id_from_dc(dc_identifier)}_METS.xml"
         else:
             path = f"{folder_path}/{file_name}"
 

--- a/harvester/pmh_interface.py
+++ b/harvester/pmh_interface.py
@@ -45,6 +45,7 @@ class PMH_API:
 
         mets_url = f"{dc_identifier}/mets.xml?full=true"
         xml_response = requests.get(mets_url, timeout=5)
+        xml_response.raise_for_status()
 
         if not file_name:
             path = f"{folder_path}/{utils.binding_id_from_dc(dc_identifier)}_METS.xml"

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -1,0 +1,13 @@
+"""
+General utility functions for working with the OAI-PMH API, metadata and files.
+"""
+
+
+def binding_id_from_dc(dc_identifier):
+    """
+    Parse binding ID from dc_identifier URL.
+
+    :param dc_identifier: DC identifier of a record
+    :type dc_identifier: str
+    """
+    return dc_identifier.split("/")[-1]

--- a/harvester_cli.py
+++ b/harvester_cli.py
@@ -35,7 +35,7 @@ def binding_ids(ctx, set_id):
     # pylint does not understand that variables are inherited from the command
     # group
     # pylint: disable=undefined-variable
-    ids = ctx.obj["API"].binding_ids(set_id)
+    ids = ctx.obj["API"].dc_identifiers(set_id)
     for id_ in ids:
         click.echo(id_)
 
@@ -48,8 +48,8 @@ def checksums(mets_file_path, encoding):
     Output checksums for all files listed in the METS document.
     """
     mets = METS(mets_file_path, encoding)
-    for checksum in mets.checksums():
-        click.echo(checksum)
+    for file in mets.files():
+        click.echo(file.checksum)
 
 
 if __name__ == "__main__":

--- a/harvester_cli.py
+++ b/harvester_cli.py
@@ -9,33 +9,28 @@ from harvester.mets import METS
 
 
 @click.group()
-@click.pass_context
+def cli():
+    """
+    Harvester for OAI-PMH data.
+    """
+
+
+@cli.command
+@click.argument("set_id")
 @click.option(
     "--url",
     default="https://digi.kansalliskirjasto.fi/interfaces/OAI-PMH",
     help="URL of the OAI-PMH API to be used",
 )
-def cli(ctx, url):  # pylint: disable=unused-argument
-    """
-    Harvester for OAI-PMH data.
-    """
-    ctx.ensure_object(dict)
-
-    api = PMH_API(url)
-    ctx.obj["API"] = api
-
-
-@cli.command
-@click.pass_context
-@click.argument("set_id")
-def binding_ids(ctx, set_id):
+def binding_ids(set_id, url):
     """
     Fetch all binding IDs in the given set.
     """
     # pylint does not understand that variables are inherited from the command
     # group
     # pylint: disable=undefined-variable
-    ids = ctx.obj["API"].dc_identifiers(set_id)
+    api = PMH_API(url)
+    ids = api.dc_identifiers(set_id)
     for id_ in ids:
         click.echo(id_)
 
@@ -46,10 +41,42 @@ def binding_ids(ctx, set_id):
 def checksums(mets_file_path, encoding):
     """
     Output checksums for all files listed in the METS document.
+
+    \b
+    METS_FILE_PATH:
+        Path to the METS file to be read
     """
     mets = METS(mets_file_path, encoding)
     for file in mets.files():
         click.echo(file.checksum)
+
+
+@cli.command
+@click.argument("mets_file_path")
+@click.argument(
+    "collection_dc_identifier",
+)
+@click.option("--encoding", default="utf-8")
+def download_urls(mets_file_path, collection_dc_identifier, encoding):
+    """
+    Print dwnload URLs for all files in METS
+
+    \b
+    METS_FILE_PATH:
+        Path to the METS file to be read
+
+    \b
+    COLLECTION_DC_IDENTIFIER:
+        Dublin Core identifier for the collection to
+        which the binding described by this METS belongs. E.g.
+        https://digi.kansalliskirjasto.fi/sanomalehti/binding/380082.
+    """
+    mets = METS(mets_file_path, encoding)
+    for file in mets.files():
+        try:
+            click.echo(file.download_url(collection_dc_identifier))
+        except NotImplementedError:
+            click.echo(f"No download URL available for file {file.location_xlink}")
 
 
 if __name__ == "__main__":

--- a/harvester_cli.py
+++ b/harvester_cli.py
@@ -57,7 +57,7 @@ def checksums(mets_file_path, encoding):
     "collection_dc_identifier",
 )
 @click.option("--encoding", default="utf-8")
-def download_urls(mets_file_path, collection_dc_identifier, encoding):
+def list_download_urls(mets_file_path, collection_dc_identifier, encoding):
     """
     Print download URLs for all files in METS
 
@@ -75,6 +75,39 @@ def download_urls(mets_file_path, collection_dc_identifier, encoding):
     for file in mets.files():
         try:
             click.echo(file.download_url)
+        except NotImplementedError:
+            click.echo(f"No download URL available for file {file.location_xlink}")
+
+
+@cli.command
+@click.argument("mets_file_path")
+@click.argument(
+    "collection_dc_identifier",
+)
+@click.option("--encoding", default="utf-8")
+@click.option(
+    "--base-path",
+    default=None,
+    help="The location under which the structure of downloaded files is created",
+)
+def download_files_from(mets_file_path, collection_dc_identifier, encoding, base_path):
+    """
+    Print download URLs for all files in METS
+
+    \b
+    METS_FILE_PATH:
+        Path to the METS file to be read
+
+    \b
+    COLLECTION_DC_IDENTIFIER:
+        Dublin Core identifier for the collection to
+        which the binding described by this METS belongs. E.g.
+        https://digi.kansalliskirjasto.fi/sanomalehti/binding/380082.
+    """
+    mets = METS(mets_file_path, collection_dc_identifier, encoding)
+    for file in mets.files():
+        try:
+            file.download(base_path=base_path)
         except NotImplementedError:
             click.echo(f"No download URL available for file {file.location_xlink}")
 

--- a/harvester_cli.py
+++ b/harvester_cli.py
@@ -59,7 +59,7 @@ def checksums(mets_file_path, encoding):
 @click.option("--encoding", default="utf-8")
 def download_urls(mets_file_path, collection_dc_identifier, encoding):
     """
-    Print dwnload URLs for all files in METS
+    Print download URLs for all files in METS
 
     \b
     METS_FILE_PATH:
@@ -71,10 +71,10 @@ def download_urls(mets_file_path, collection_dc_identifier, encoding):
         which the binding described by this METS belongs. E.g.
         https://digi.kansalliskirjasto.fi/sanomalehti/binding/380082.
     """
-    mets = METS(mets_file_path, encoding)
+    mets = METS(mets_file_path, collection_dc_identifier, encoding)
     for file in mets.files():
         try:
-            click.echo(file.download_url(collection_dc_identifier))
+            click.echo(file.download_url)
         except NotImplementedError:
             click.echo(f"No download URL available for file {file.location_xlink}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,14 @@ def mets_dc_identifier():
 
 
 @pytest.fixture
+def simple_mets_path():
+    """
+    Path to METS with one location for each file
+    """
+    return "tests/data/379973_METS.xml"
+
+
+@pytest.fixture
 def expected_mets_response(mets_dc_identifier):
     """
     Patch a GET request for fetching a METS file for a given binding id.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 Test fixtures
 """
 
+import os
 import pytest
 import requests_mock
 
@@ -115,3 +116,14 @@ def expected_mets_response(mets_dc_identifier):
         )
         mocker.get(mets_url, text=mets_content)
         yield mets_content
+
+
+@pytest.fixture
+def cwd_in_tmp(tmp_path):
+    """
+    Change current working directory into a temporary directory.
+    """
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    yield tmp_path
+    os.chdir(original_cwd)

--- a/tests/harvester/test_file.py
+++ b/tests/harvester/test_file.py
@@ -2,7 +2,6 @@
 Tests for File and its subclasses.
 """
 
-import os
 from pathlib import Path
 
 import pytest
@@ -13,17 +12,6 @@ from harvester.file import File, ALTOFile
 
 # Pylint does not understand fixture use
 # pylint: disable=redefined-outer-name
-
-
-@pytest.fixture
-def cwd_in_tmp(tmp_path):
-    """
-    Change current working directory into a temporary directory.
-    """
-    original_cwd = os.getcwd()
-    os.chdir(tmp_path)
-    yield tmp_path
-    os.chdir(original_cwd)
 
 
 @pytest.fixture

--- a/tests/harvester/test_file.py
+++ b/tests/harvester/test_file.py
@@ -2,24 +2,130 @@
 Tests for File and its subclasses.
 """
 
+import os
+from pathlib import Path
+
+import pytest
+import requests_mock
+
 from harvester.file import File, ALTOFile
+
+
+# Pylint does not understand fixture use
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture
+def cwd_in_tmp(tmp_path):
+    """
+    Change current working directory into a temporary directory.
+    """
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    yield tmp_path
+    os.chdir(original_cwd)
+
+
+@pytest.fixture
+def alto_url():
+    """
+    Return the DC identifier for an ALTO test file
+    """
+    return "https://example.com/1234"
+
+
+@pytest.fixture()
+def alto_filename():
+    """
+    Return the filename for an ALTO test file
+    """
+    return "00002.xml"
+
+
+@pytest.fixture
+def alto_file(alto_url, alto_filename):
+    """
+    Return an ALTOFile for testing.
+    """
+    return ALTOFile(
+        "test_checksum",
+        "test_algo",
+        f"file://./alto/{alto_filename}",
+        alto_url,
+    )
+
+
+@pytest.fixture
+def mock_alto_download(alto_url, alto_filename):
+    """
+    Fake a response for GETting an ALTO file from "NLF".
+
+    We don't really need the proper contents of an ALTO file, so the response contains
+    just dummy data.
+    """
+    alto_file_content = "<xml>test cöntent</xml>"
+    with requests_mock.Mocker() as mocker:
+        mocker.get(
+            f"{alto_url}/page-{alto_filename}",
+            content=alto_file_content.encode("utf-8"),
+        )
+        yield alto_file_content
 
 
 def test_file_initialized_values():
     """
     Check that the values given when initializing are utilized correctly
     """
-    test_file = File("test_checksum", "test_algo", "test_location")
+    test_file = File(
+        "test_checksum", "test_algo", "test_location", "test_dc_identifier"
+    )
     assert test_file.checksum == "test_checksum"
     assert test_file.algorithm == "test_algo"
     assert test_file.location_xlink == "test_location"
+    assert test_file.binding_dc_identifier == "test_dc_identifier"
 
 
-def test_alto_download_url():
+def test_alto_download_url(alto_file, alto_url, alto_filename):
     """
     Ensure that the download URL is formed using the filename and dc_identifier.
     """
-    alto_file = ALTOFile("test_checksum", "test_algo", "file://./alto/00002.xml")
-    download_url = alto_file.download_url(dc_identifier="https://example.com/1234")
+    assert alto_file.download_url == f"{alto_url}/page-{alto_filename}"
 
-    assert download_url == "https://example.com/1234/page-00002.xml"
+
+def test_filename(alto_file, alto_filename):
+    """
+    Ensure that determining the file name based on the xpath works.
+    """
+    assert alto_file.filename == alto_filename
+
+
+def test_download_to_default_path(
+    alto_file, cwd_in_tmp, mock_alto_download, alto_filename
+):
+    """
+    Test downloading an ALTO file to the default location.
+    """
+    alto_file.download()
+    expected_output_path = (
+        Path(cwd_in_tmp) / "downloads" / "1234" / "alto" / alto_filename
+    )
+    assert expected_output_path.is_file()
+
+    with open(expected_output_path, "r", encoding="utf-8") as alto:
+        assert alto.read() == mock_alto_download
+
+
+def test_download_to_custom_path(alto_file, mock_alto_download, tmpdir):
+    """
+    Ensure that downloaded files are saved into the specified location.
+    """
+    alto_file.download(
+        base_path=tmpdir,
+        file_dir="some/sub/path",
+        filename="test_alto.xml",
+    )
+    expected_output_path = Path(tmpdir) / "some" / "sub" / "path" / "test_alto.xml"
+    assert expected_output_path.is_file()
+
+    with open(expected_output_path, "r", encoding="utf-8") as alto:
+        assert alto.read() == mock_alto_download

--- a/tests/harvester/test_file.py
+++ b/tests/harvester/test_file.py
@@ -1,0 +1,25 @@
+"""
+Tests for File and its subclasses.
+"""
+
+from harvester.file import File, ALTOFile
+
+
+def test_file_initialized_values():
+    """
+    Check that the values given when initializing are utilized correctly
+    """
+    test_file = File("test_checksum", "test_algo", "test_location")
+    assert test_file.checksum == "test_checksum"
+    assert test_file.algorithm == "test_algo"
+    assert test_file.location_xlink == "test_location"
+
+
+def test_alto_download_url():
+    """
+    Ensure that the download URL is formed using the filename and dc_identifier.
+    """
+    alto_file = ALTOFile("test_checksum", "test_algo", "file://./alto/00002.xml")
+    download_url = alto_file.download_url(dc_identifier="https://example.com/1234")
+
+    assert download_url == "https://example.com/1234/page-00002.xml"

--- a/tests/harvester/test_mets.py
+++ b/tests/harvester/test_mets.py
@@ -14,6 +14,14 @@ from harvester.mets import METS
 
 
 @pytest.fixture
+def simple_mets_object(simple_mets_path):
+    """
+    Return a METS object representing a simple, well-formed METS file.
+    """
+    return METS(simple_mets_path, "https://example.com/dc_identifier/1234")
+
+
+@pytest.fixture
 def mets_with_multiple_file_locations(simple_mets_path, tmp_path):
     """
     Return a path to METS file that has a file with two locations
@@ -43,12 +51,11 @@ def mets_with_multiple_file_locations(simple_mets_path, tmp_path):
     return mets_output_path
 
 
-def test_file_checksum_parsing(simple_mets_path):
+def test_file_checksum_parsing(simple_mets_object):
     """
     Test checksum parsing when there's one location for each file.
     """
-    mets = METS(simple_mets_path)
-    files = list(mets.files())
+    files = list(simple_mets_object.files())
 
     first_file = files[0]
     assert first_file.checksum == "ab64aff5f8375ca213eeaee260edcefe"
@@ -59,12 +66,11 @@ def test_file_checksum_parsing(simple_mets_path):
     assert last_file.algorithm == "MD5"
 
 
-def test_file_location_parsing(simple_mets_path):
+def test_file_location_parsing(simple_mets_object):
     """
     Test file location parsing when there's one location for each file.
     """
-    mets = METS(simple_mets_path)
-    files = list(mets.files())
+    files = list(simple_mets_object.files())
 
     first_file = files[0]
     assert first_file.location_xlink == "file://./preservation_img/pr-00001.jp2"
@@ -83,7 +89,7 @@ def test_files_exception_on_two_locations_for_a_file(
     the pipeline (e.g. trying to use a URL to determine the location of a file
     in a zip package).
     """
-    mets = METS(mets_with_multiple_file_locations)
+    mets = METS(mets_with_multiple_file_locations, "dummy_dc_identifier")
     with pytest.raises(METSLocationParseError):
         for _ in mets.files():
             pass

--- a/tests/harvester/test_mets.py
+++ b/tests/harvester/test_mets.py
@@ -5,7 +5,8 @@ Tests for the METSParser
 import pytest
 from lxml import etree
 
-from harvester.mets import METS, METSLocationParseError
+from harvester.file import METSLocationParseError
+from harvester.mets import METS
 
 
 @pytest.fixture

--- a/tests/harvester/test_mets.py
+++ b/tests/harvester/test_mets.py
@@ -9,20 +9,12 @@ from harvester.file import METSLocationParseError
 from harvester.mets import METS
 
 
-@pytest.fixture
-def simple_mets():
-    """
-    METS with one location for each file
-    """
-    return "tests/data/379973_METS.xml"
-
-
 # Pylint does not understand fixtures
 # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture
-def mets_with_multiple_file_locations(simple_mets, tmp_path):
+def mets_with_multiple_file_locations(simple_mets_path, tmp_path):
     """
     Return a path to METS file that has a file with two locations
     """
@@ -30,7 +22,7 @@ def mets_with_multiple_file_locations(simple_mets, tmp_path):
     # an accurate view into the lxml library. This disables false alarms.
     # pylint: disable=c-extension-no-member
 
-    with open(simple_mets, "r", encoding="utf-8") as mets_file:
+    with open(simple_mets_path, "r", encoding="utf-8") as mets_file:
         mets_tree = etree.parse(mets_file)
     files = mets_tree.xpath(
         "mets:fileSec/mets:fileGrp/mets:file",
@@ -51,11 +43,11 @@ def mets_with_multiple_file_locations(simple_mets, tmp_path):
     return mets_output_path
 
 
-def test_file_checksum_parsing(simple_mets):
+def test_file_checksum_parsing(simple_mets_path):
     """
     Test checksum parsing when there's one location for each file.
     """
-    mets = METS(simple_mets)
+    mets = METS(simple_mets_path)
     files = list(mets.files())
 
     first_file = files[0]
@@ -67,11 +59,11 @@ def test_file_checksum_parsing(simple_mets):
     assert last_file.algorithm == "MD5"
 
 
-def test_file_location_parsing(simple_mets):
+def test_file_location_parsing(simple_mets_path):
     """
     Test file location parsing when there's one location for each file.
     """
-    mets = METS(simple_mets)
+    mets = METS(simple_mets_path)
     files = list(mets.files())
 
     first_file = files[0]

--- a/tests/harvester/test_pmh_interface.py
+++ b/tests/harvester/test_pmh_interface.py
@@ -5,6 +5,7 @@ Tests for PMH_API
 import builtins
 
 from harvester.pmh_interface import PMH_API
+from harvester import utils
 
 
 def _check_result(ids, expected_info):
@@ -33,14 +34,6 @@ def test_binding_ids_from_two_page_response(oai_pmh_api_url, two_page_pmh_respon
     _check_result(ids, two_page_pmh_response)
 
 
-def test_binding_id_from_dc(oai_pmh_api_url, mets_dc_identifier):
-    """
-    Test that DC identifiers are parsed to binding IDs correctly.
-    """
-    api = PMH_API(oai_pmh_api_url)
-    assert api.binding_id_from_dc(mets_dc_identifier) == "379973"
-
-
 def test_fetch_mets_with_filename(
     oai_pmh_api_url, mets_dc_identifier, expected_mets_response, tmp_path, mocker
 ):
@@ -48,7 +41,7 @@ def test_fetch_mets_with_filename(
     Ensure that a valid METS file is fetched and written to disk with file_name.
     """
     api = PMH_API(oai_pmh_api_url)
-    binding_id = api.binding_id_from_dc(mets_dc_identifier)
+    binding_id = utils.binding_id_from_dc(mets_dc_identifier)
     mocker.patch("builtins.open")
     response = api.fetch_mets(mets_dc_identifier, tmp_path, f"{binding_id}_METS.xml")
     builtins.open.assert_called_once_with(str(tmp_path / f"{binding_id}_METS.xml"), "w")
@@ -62,7 +55,7 @@ def test_fetch_mets_without_filename(
     Ensure that a valid METS file is fetched and written to disk without file_name.
     """
     api = PMH_API(oai_pmh_api_url)
-    binding_id = api.binding_id_from_dc(mets_dc_identifier)
+    binding_id = utils.binding_id_from_dc(mets_dc_identifier)
     mocker.patch("builtins.open")
     response = api.fetch_mets(mets_dc_identifier, tmp_path)
     builtins.open.assert_called_once_with(str(tmp_path / f"{binding_id}_METS.xml"), "w")

--- a/tests/harvester/test_utils.py
+++ b/tests/harvester/test_utils.py
@@ -1,0 +1,12 @@
+"""
+Tests for utility functions.
+"""
+
+from harvester import utils
+
+
+def test_binding_id_from_dc(mets_dc_identifier):
+    """
+    Test that DC identifiers are parsed to binding IDs correctly.
+    """
+    assert utils.binding_id_from_dc(mets_dc_identifier) == "379973"

--- a/tests/test_harvester_cli.py
+++ b/tests/test_harvester_cli.py
@@ -19,8 +19,8 @@ def test_binding_ids_with_url(oai_pmh_api_url, two_page_pmh_response, two_page_s
     result = runner.invoke(
         cli,
         [
-            "--url", oai_pmh_api_url,
             "binding-ids",
+            "--url", oai_pmh_api_url,
             two_page_set_id,
         ],
     )
@@ -68,3 +68,22 @@ def test_checksums(simple_mets_path):
         ],
     )
     assert "\n33cbc005ce7dac534bdcc424c8a082cd\n" in result.output
+
+
+def test_download_urls(simple_mets_path):
+    """
+    Check that the CLI is able to call the `download_urls` function.
+
+    At the time of writing this test, we do not have the functionality for identifying
+    different types of files, so the output does not contain relevant information to
+    check. It is advised to edit this test as support is added for new file types.
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["download-urls", simple_mets_path, "https://example.com/1234"],
+    )
+
+    # four pages, alto and access image for each, plus a trailing newline
+    assert len(result.output.split("\n")) == 8 + 1

--- a/tests/test_harvester_cli.py
+++ b/tests/test_harvester_cli.py
@@ -5,10 +5,11 @@ This means that the bare minimum is likely often enough: as long as the method a
 parameter names are ok, things are likely fine.
 """
 
-import os
+import re
 import sys
 
 import pytest
+import requests_mock
 
 from click.testing import CliRunner
 from harvester_cli import cli
@@ -85,7 +86,7 @@ def test_checksums(simple_mets_path):
 
 
 @requires_37
-def test_download_urls(simple_mets_path):
+def test_list_download_urls(simple_mets_path):
     """
     Check that the CLI is able to call the `download_urls` function.
 
@@ -97,8 +98,42 @@ def test_download_urls(simple_mets_path):
 
     result = runner.invoke(
         cli,
-        ["download-urls", simple_mets_path, "https://example.com/1234"],
+        ["list-download-urls", simple_mets_path, "https://example.com/1234"],
     )
 
     # four pages, alto and access image for each, plus a trailing newline
     assert len(result.output.split("\n")) == 8 + 1
+
+
+@pytest.fixture
+def dummy_response_to_all_downloads():
+    """
+    Return a test response to all file download requests to NLF.
+    """
+    download_urls = re.compile("https://example.com/1234/.*")
+    with requests_mock.Mocker() as mocker:
+        mocker.get(download_urls, content=b"test content")
+        yield
+
+
+@requires_37
+@pytest.mark.usefixtures("dummy_response_to_all_downloads")
+def test_download_files_from(simple_mets_path, tmpdir):
+    """
+    Check that `download()` is called for each file listed in METS.
+
+    It is enough that no exceptions rise.
+    """
+    runner = CliRunner()
+
+    runner.invoke(
+        cli,
+        [
+            "download-files-from",
+            simple_mets_path,
+            "https://example.com/1234",
+            "--base-path",
+            tmpdir,
+        ],
+        catch_exceptions=False,
+    )

--- a/tests/test_harvester_cli.py
+++ b/tests/test_harvester_cli.py
@@ -36,6 +36,7 @@ def test_binding_ids_with_url(oai_pmh_api_url, two_page_pmh_response, two_page_s
             "--url", oai_pmh_api_url,
             two_page_set_id,
         ],
+        catch_exceptions=False,
     )
     # fmt: on
 
@@ -59,6 +60,7 @@ def test_binding_ids_from_default_url(two_page_pmh_response, two_page_set_id):
             "binding-ids",
             two_page_set_id,
         ],
+        catch_exceptions=False,
     )
 
     # One extra line for line feed at the end
@@ -81,6 +83,7 @@ def test_checksums(simple_mets_path):
             "checksums",
             simple_mets_path,
         ],
+        catch_exceptions=False,
     )
     assert "\n33cbc005ce7dac534bdcc424c8a082cd\n" in result.output
 
@@ -99,6 +102,7 @@ def test_list_download_urls(simple_mets_path):
     result = runner.invoke(
         cli,
         ["list-download-urls", simple_mets_path, "https://example.com/1234"],
+        catch_exceptions=False,
     )
 
     # four pages, alto and access image for each, plus a trailing newline

--- a/tests/test_harvester_cli.py
+++ b/tests/test_harvester_cli.py
@@ -5,10 +5,22 @@ This means that the bare minimum is likely often enough: as long as the method a
 parameter names are ok, things are likely fine.
 """
 
+import os
+import sys
+
+import pytest
+
 from click.testing import CliRunner
 from harvester_cli import cli
 
 
+requires_37 = pytest.mark.skipif(
+    sys.version_info < (3, 7),
+    reason="CliRunner is buggy on click8.0 and newer ones require python3.7 or higher",
+)
+
+
+@requires_37
 def test_binding_ids_with_url(oai_pmh_api_url, two_page_pmh_response, two_page_set_id):
     """
     Test that the CLI can fetch binding IDs from a specific URL
@@ -33,6 +45,7 @@ def test_binding_ids_with_url(oai_pmh_api_url, two_page_pmh_response, two_page_s
     assert two_page_pmh_response["first_id"] in result.output
 
 
+@requires_37
 def test_binding_ids_from_default_url(two_page_pmh_response, two_page_set_id):
     """
     Test that the CLI can fetch binding IDs from default API URL when not given
@@ -54,6 +67,7 @@ def test_binding_ids_from_default_url(two_page_pmh_response, two_page_set_id):
     assert two_page_pmh_response["first_id"] in result.output
 
 
+@requires_37
 def test_checksums(simple_mets_path):
     """
     Check that at least one correct checksum is printed
@@ -70,6 +84,7 @@ def test_checksums(simple_mets_path):
     assert "\n33cbc005ce7dac534bdcc424c8a082cd\n" in result.output
 
 
+@requires_37
 def test_download_urls(simple_mets_path):
     """
     Check that the CLI is able to call the `download_urls` function.

--- a/tests/test_harvester_cli.py
+++ b/tests/test_harvester_cli.py
@@ -1,0 +1,70 @@
+"""
+Tests for ensuring that the CLI stays functional in refactorings.
+
+This means that the bare minimum is likely often enough: as long as the method and
+parameter names are ok, things are likely fine.
+"""
+
+from click.testing import CliRunner
+from harvester_cli import cli
+
+
+def test_binding_ids_with_url(oai_pmh_api_url, two_page_pmh_response, two_page_set_id):
+    """
+    Test that the CLI can fetch binding IDs from a specific URL
+    """
+    runner = CliRunner()
+
+    # fmt: off
+    result = runner.invoke(
+        cli,
+        [
+            "--url", oai_pmh_api_url,
+            "binding-ids",
+            two_page_set_id,
+        ],
+    )
+    # fmt: on
+
+    # One extra line for line feed at the end
+    assert len(result.output.split("\n")) == two_page_pmh_response["length"] + 1
+
+    assert two_page_pmh_response["last_id"] in result.output
+    assert two_page_pmh_response["first_id"] in result.output
+
+
+def test_binding_ids_from_default_url(two_page_pmh_response, two_page_set_id):
+    """
+    Test that the CLI can fetch binding IDs from default API URL when not given
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        [
+            "binding-ids",
+            two_page_set_id,
+        ],
+    )
+
+    # One extra line for line feed at the end
+    assert len(result.output.split("\n")) == two_page_pmh_response["length"] + 1
+
+    assert two_page_pmh_response["last_id"] in result.output
+    assert two_page_pmh_response["first_id"] in result.output
+
+
+def test_checksums(simple_mets_path):
+    """
+    Check that at least one correct checksum is printed
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        [
+            "checksums",
+            simple_mets_path,
+        ],
+    )
+    assert "\n33cbc005ce7dac534bdcc424c8a082cd\n" in result.output


### PR DESCRIPTION
Add machinery for downloading files.

As an attempt for sane defaults, the default download location is constructed from `base_path`, `file_dir` and `file_name`, the defaults of which are set in the following manner:
```
./downloads/[filetype dependent directory]/[filename from location_xlink]
^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 base_path             file_dir                      file_name
 ```
which can result in e.g. `./downloads/1234/alto/00002.xml` for an ALTO file from binding 1234.

Each part can be overridden separately to e.g. keep the subdirectory structure but change the base path.