### PR TITLE
KP-6520 Hack ALTO file paths for download links

### DIFF
--- a/harvester/file.py
+++ b/harvester/file.py
@@ -58,8 +58,7 @@ class File:
         children = file_element.getchildren()
         if len(children) != 1:
             raise METSLocationParseError("Expected 1 location, found {len(children)}")
-        location_key = [key for key in children[0].attrib if key.endswith("href")][0]
-        location = children[0].attrib[location_key]
+        location = file_element.xpath("./*/@*[local-name()='href']")[0]
         parent = file_element.getparent()
 
         if (

--- a/harvester/file.py
+++ b/harvester/file.py
@@ -6,6 +6,7 @@ page from a newspaper, or a jpeg showing the scanned page).
 import os
 from pathlib import Path
 import requests
+import re
 
 from harvester import utils
 
@@ -57,8 +58,8 @@ class File:
         children = file_element.getchildren()
         if len(children) != 1:
             raise METSLocationParseError("Expected 1 location, found {len(children)}")
-        location = children[0].attrib["{http://www.w3.org/TR/xlink}href"]
-
+        location_key = [key for key in children[0].attrib if key.endswith("href")][0]
+        location = children[0].attrib[location_key]
         parent = file_element.getparent()
 
         if (
@@ -174,6 +175,8 @@ class ALTOFile(File):
         :type dc_identifier: String
         """
         href_filename = self.location_xlink.rsplit("/", maxsplit=1)[-1]
+        if not re.match(r"^0+([1-9]+0*)+.xml$", href_filename):
+            href_filename = f"{re.search(r'([1-9]+0*)+', href_filename).group(0)}.xml"
         return f"{self.binding_dc_identifier}/page-{href_filename}"
 
     def _default_file_dir(self):

--- a/harvester/file.py
+++ b/harvester/file.py
@@ -176,7 +176,14 @@ class ALTOFile(File):
         """
         href_filename = self.location_xlink.rsplit("/", maxsplit=1)[-1]
         if not re.match(r"^0+([1-9]+0*)+.xml$", href_filename):
-            href_filename = f"{re.search(r'([1-9]+0*)+', href_filename).group(0)}.xml"
+            try:
+                href_filename = (
+                    f"{re.search(r'([1-9]+0*)+', href_filename).group(0)}.xml"
+                )
+            except AttributeError:
+                raise AttributeError(
+                    f"ALTO filename {href_filename} does not follow the accepted convention."
+                )
         return f"{self.binding_dc_identifier}/page-{href_filename}"
 
     def _default_file_dir(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,6 +189,19 @@ def alto_file_with_erroneous_name(alto_url):
 
 
 @pytest.fixture
+def alto_file_with_parsable_name(alto_url):
+    """
+    Return an ALTOfile with a non-standard, but parsable and working filename.
+    """
+    return ALTOFile(
+        "test_checksum",
+        "test_algo",
+        "file://./alto/img0001-alto.xml",
+        alto_url,
+    )
+
+
+@pytest.fixture
 def mock_alto_download(alto_url, alto_filename):
     """
     Fake a response for GETting an ALTO file from "NLF".

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,19 @@ def alto_file(alto_url, alto_filename):
 
 
 @pytest.fixture
+def alto_file_with_erroneous_name(alto_url):
+    """
+    Return an ALTOFile with an erroneus filename for testing.
+    """
+    return ALTOFile(
+        "test_checksum",
+        "test_algo",
+        "file://./alto/alto.xml",
+        alto_url,
+    )
+
+
+@pytest.fixture
 def mock_alto_download(alto_url, alto_filename):
     """
     Fake a response for GETting an ALTO file from "NLF".

--- a/tests/harvester/test_file.py
+++ b/tests/harvester/test_file.py
@@ -50,6 +50,16 @@ def test_erroneus_filename(alto_file_with_erroneous_name):
         alto_file_with_erroneous_name.download_url()
 
 
+def test_parsable_filename(alto_file_with_parsable_name):
+    """
+    Ensure that an ALTO file with a non-standard name gets parsed correctly.
+    """
+    assert (
+        alto_file_with_parsable_name.download_url.rsplit("/", maxsplit=1)[-1]
+        == "page-1.xml"
+    )
+
+
 def test_download_to_default_path(
     alto_file, cwd_in_tmp, mock_alto_download, alto_filename
 ):

--- a/tests/harvester/test_file.py
+++ b/tests/harvester/test_file.py
@@ -46,7 +46,7 @@ def test_erroneus_filename(alto_file_with_erroneous_name):
     """
     Ensure that an erroneous ALTO filename raises an error.
     """
-    with pytest.raises(AttributeError, match=r".* alto.xml .*") as e:
+    with pytest.raises(AttributeError, match=r".* alto.xml .*"):
         alto_file_with_erroneous_name.download_url()
 
 

--- a/tests/harvester/test_file.py
+++ b/tests/harvester/test_file.py
@@ -42,6 +42,14 @@ def test_filename(alto_file, alto_filename):
     assert alto_file.filename == alto_filename
 
 
+def test_erroneus_filename(alto_file_with_erroneous_name):
+    """
+    Ensure that an erroneous ALTO filename raises an error.
+    """
+    with pytest.raises(AttributeError, match=r".* alto.xml .*") as e:
+        alto_file_with_erroneous_name.download_url()
+
+
 def test_download_to_default_path(
     alto_file, cwd_in_tmp, mock_alto_download, alto_filename
 ):


### PR DESCRIPTION
Fixed the extraction of file paths from METS files (the previous logic was too restrictive) and added logic to extract ALTO paths for download URLs, when the path listed in METS does not follow the expected convention and results in a broken download URL.

I tested this by downloading ALTOs for one DC identifier for each collection available from the API. Testing did not reveal any issues with the path formation logic. 