### PR TITLE
KP-6211 Specify requirements for Airflow pipeline too

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ virtualenv .venv -p python3
 make requirements
 ```
 
+If you want to test the Airflow pipelines too, you need to install some
+additional packages:
+```
+pip install -r pipeline/requirements.txt
+```
+
 ### Running Unit Tests
 Without coverage information:
 ```

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,4 +1,1 @@
-click
-lxml
-sickle
-more_itertools
+apache-airflow-providers-ssh


### PR DESCRIPTION
Previously there were identical requirements.txt files in the repository root and in the pipeline directory. Now the one in the one in the pipeline directory defines the pipeline-specific requirements. This is handy because now we don't need to sprinkle hard-coded requirements into Ansible roles.

This is required for https://github.com/CSCfi/Kielipankki/pull/69/commits/63c2ca28ae8ccf24f5a7873bdae86c1c012d0f4a.