### PR TITLE
KP-6568 Fixes to enable download of all available collections

### DIFF
--- a/pipeline/dags/download_all_sets.py
+++ b/pipeline/dags/download_all_sets.py
@@ -15,13 +15,15 @@ from operators.custom_operators import (
 )
 
 
-BASE_PATH = "/scratch/project_2006633/nlf-harvester/downloads"
+BASE_PATH = "/scratch/project_2006633/nlf-harvester/nlf_collections"
 
 default_args = {
     "owner": "Kielipankki",
     "start_date": "2022-10-01",
-    "retries": 5,
-    "retry_delay": timedelta(seconds=10),
+    "retries": 4,
+    "retry_delay": timedelta(minutes=10),
+    "email": ["helmiina.hotti@csc.fi"],
+    "email_on_failure": True
 }
 
 

--- a/pipeline/dags/download_all_sets.py
+++ b/pipeline/dags/download_all_sets.py
@@ -23,7 +23,7 @@ default_args = {
     "retries": 4,
     "retry_delay": timedelta(minutes=10),
     "email": ["helmiina.hotti@csc.fi"],
-    "email_on_failure": True
+    "email_on_failure": True,
 }
 
 

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -14,10 +14,6 @@ from harvester import utils
 
 from requests.exceptions import HTTPError
 
-import logging
-
-LOGGER = logging.getLogger("airflow.task")
-
 
 class CreateConnectionOperator(BaseOperator):
     """
@@ -143,7 +139,7 @@ class SaveMetsSFTPOperator(BaseOperator):
                     dc_identifier=self.dc_identifier, output_mets_file=file
                 )
             except HTTPError as e:
-                LOGGER.warn(
+                print(
                     f"Download of METS file {self.dc_identifier} failed with code {e.response.status_code}"
                 )
                 self.sftp_client.remove(output_file)
@@ -215,8 +211,8 @@ class SaveMetsForAllSetsSFTPOperator(BaseOperator):
                 sftp_client=sftp_client,
                 remote_directory=f"{self.base_path}/mets",
             )
-            for set_id in [s for s in list(api.set_ids()) if not s.startswith(tuple("col-501", "col-82", "col-25", "col-101")) and not s.endswith("rajatut")]:
-                LOGGER.info(f"Downloading METS for set {set_id}")
+            for set_id in [s for s in list(api.set_ids()) if not s.startswith(("col-501", "col-82", "col-25", "col-101")) and not s.endswith("rajatut")]:
+                print(f"Downloading METS for set {set_id}")
                 SaveMetsForSetSFTPOperator(
                     task_id=f"save_mets_for_{set_id.replace(':', '_')}",
                     http_conn_id=self.http_conn_id,
@@ -282,7 +278,7 @@ class SaveAltosForMetsSFTPOperator(BaseOperator):
                         chunk_size=10 * 1024 * 1024,
                     )
                 except HTTPError as e:
-                    LOGGER.warn(f"File download failed with URL {alto_file.download_url} with code {e.response.status_code}")
+                    print(f"File download failed with URL {alto_file.download_url} with code {e.response.status_code}")
                     self.sftp_client.remove(output_file)
                     continue
 
@@ -342,8 +338,8 @@ class SaveAltosForAllSetsSFTPOperator(BaseOperator):
         http_conn = BaseHook.get_connection(self.http_conn_id)
         api = PMH_API(url=http_conn.host)
 
-        for set_id in [s for s in list(api.set_ids()) if not s.startswith(tuple("col-501", "col-82", "col-25", "col-101")) and not s.endswith("rajatut")]:
-            LOGGER.info(f"Downloading ALTOs for set {set_id}")
+        for set_id in [s for s in list(api.set_ids()) if not s.startswith(("col-501", "col-82", "col-25", "col-101")) and not s.endswith("rajatut")]:
+            print(f"Downloading ALTOs for set {set_id}")
             SaveAltosForSetSFTPOperator(
                 task_id=f"save_altos_for_{set_id.replace(':', '_')}",
                 http_conn_id=self.http_conn_id,

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -12,8 +12,7 @@ from harvester.file import ALTOFile
 from harvester.pmh_interface import PMH_API
 from harvester import utils
 
-from requests.exceptions import HTTPError, ReadTimeout
-from urllib3.exceptions import ReadTimeoutError
+from requests.exceptions import RequestException
 
 
 class CreateConnectionOperator(BaseOperator):
@@ -139,7 +138,7 @@ class SaveMetsSFTPOperator(BaseOperator):
                 self.api.download_mets(
                     dc_identifier=self.dc_identifier, output_mets_file=file
                 )
-            except (HTTPError, ReadTimeout, ReadTimeoutError, TimeoutError) as e:
+            except RequestException as e:
                 print(
                     f"Download of METS file {self.dc_identifier} failed with code {e.response.status_code}"
                 )
@@ -286,7 +285,7 @@ class SaveAltosForMetsSFTPOperator(BaseOperator):
                         output_file=file,
                         chunk_size=10 * 1024 * 1024,
                     )
-                except (HTTPError, ReadTimeout, ReadTimeoutError, TimeoutError) as e:
+                except RequestException as e:
                     print(
                         f"File download failed with URL {alto_file.download_url} with code {e.response.status_code}"
                     )

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -12,7 +12,7 @@ from harvester.file import ALTOFile
 from harvester.pmh_interface import PMH_API
 from harvester import utils
 
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ReadTimeout
 
 
 class CreateConnectionOperator(BaseOperator):
@@ -138,7 +138,7 @@ class SaveMetsSFTPOperator(BaseOperator):
                 self.api.download_mets(
                     dc_identifier=self.dc_identifier, output_mets_file=file
                 )
-            except HTTPError as e:
+            except (HTTPError, ReadTimeout) as e:
                 print(
                     f"Download of METS file {self.dc_identifier} failed with code {e.response.status_code}"
                 )
@@ -211,7 +211,12 @@ class SaveMetsForAllSetsSFTPOperator(BaseOperator):
                 sftp_client=sftp_client,
                 remote_directory=f"{self.base_path}/mets",
             )
-            for set_id in [s for s in list(api.set_ids()) if not s.startswith(("col-501", "col-82", "col-25", "col-101")) and not s.endswith("rajatut")]:
+            for set_id in [
+                s
+                for s in list(api.set_ids())
+                if not s.startswith(("col-501", "col-82", "col-25", "col-101"))
+                and not s.endswith("rajatut")
+            ]:
                 print(f"Downloading METS for set {set_id}")
                 SaveMetsForSetSFTPOperator(
                     task_id=f"save_mets_for_{set_id.replace(':', '_')}",
@@ -277,8 +282,10 @@ class SaveAltosForMetsSFTPOperator(BaseOperator):
                         output_file=file,
                         chunk_size=10 * 1024 * 1024,
                     )
-                except HTTPError as e:
-                    print(f"File download failed with URL {alto_file.download_url} with code {e.response.status_code}")
+                except (HTTPError, ReadTimeout) as e:
+                    print(
+                        f"File download failed with URL {alto_file.download_url} with code {e.response.status_code}"
+                    )
                     self.sftp_client.remove(output_file)
                     continue
 
@@ -338,7 +345,12 @@ class SaveAltosForAllSetsSFTPOperator(BaseOperator):
         http_conn = BaseHook.get_connection(self.http_conn_id)
         api = PMH_API(url=http_conn.host)
 
-        for set_id in [s for s in list(api.set_ids()) if not s.startswith(("col-501", "col-82", "col-25", "col-101")) and not s.endswith("rajatut")]:
+        for set_id in [
+            s
+            for s in list(api.set_ids())
+            if not s.startswith(("col-501", "col-82", "col-25", "col-101"))
+            and not s.endswith("rajatut")
+        ]:
             print(f"Downloading ALTOs for set {set_id}")
             SaveAltosForSetSFTPOperator(
                 task_id=f"save_altos_for_{set_id.replace(':', '_')}",

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -14,6 +14,10 @@ from harvester import utils
 
 from requests.exceptions import HTTPError
 
+import logging
+
+LOGGER = logging.getLogger("airflow.task")
+
 
 class CreateConnectionOperator(BaseOperator):
     """
@@ -139,9 +143,10 @@ class SaveMetsSFTPOperator(BaseOperator):
                     dc_identifier=self.dc_identifier, output_mets_file=file
                 )
             except HTTPError as e:
-                print(
-                    f"Download of METS file {self.dc_identifier} failed with args {e.args}"
+                LOGGER.warn(
+                    f"Download of METS file {self.dc_identifier} failed with code {e.response.status_code}"
                 )
+                self.sftp_client.remove(output_file)
 
 
 class SaveMetsForSetSFTPOperator(BaseOperator):
@@ -210,7 +215,8 @@ class SaveMetsForAllSetsSFTPOperator(BaseOperator):
                 sftp_client=sftp_client,
                 remote_directory=f"{self.base_path}/mets",
             )
-            for set_id in api.set_ids():
+            for set_id in [s for s in list(api.set_ids()) if not s.startswith(tuple("col-501", "col-82", "col-25", "col-101")) and not s.endswith("rajatut")]:
+                LOGGER.info(f"Downloading METS for set {set_id}")
                 SaveMetsForSetSFTPOperator(
                     task_id=f"save_mets_for_{set_id.replace(':', '_')}",
                     http_conn_id=self.http_conn_id,
@@ -276,7 +282,8 @@ class SaveAltosForMetsSFTPOperator(BaseOperator):
                         chunk_size=10 * 1024 * 1024,
                     )
                 except HTTPError as e:
-                    print(f"File download failed with args {e.args}")
+                    LOGGER.warn(f"File download failed with URL {alto_file.download_url} with code {e.response.status_code}")
+                    self.sftp_client.remove(output_file)
                     continue
 
 
@@ -335,8 +342,8 @@ class SaveAltosForAllSetsSFTPOperator(BaseOperator):
         http_conn = BaseHook.get_connection(self.http_conn_id)
         api = PMH_API(url=http_conn.host)
 
-        for set_id in api.set_ids():
-            print(f"Downloading ALTOs for set {set_id}")
+        for set_id in [s for s in list(api.set_ids()) if not s.startswith(tuple("col-501", "col-82", "col-25", "col-101")) and not s.endswith("rajatut")]:
+            LOGGER.info(f"Downloading ALTOs for set {set_id}")
             SaveAltosForSetSFTPOperator(
                 task_id=f"save_altos_for_{set_id.replace(':', '_')}",
                 http_conn_id=self.http_conn_id,

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,5 +1,1 @@
-click
-lxml
-sickle
-more_itertools
 apache-airflow-providers-ssh

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,1 +1,5 @@
+click
+lxml
+sickle
+more_itertools
 apache-airflow-providers-ssh


### PR DESCRIPTION
Some changes to enable the download of all available collections from NLF with the current download logic (not depth-first and not parallelized).