### PR TITLE
Fixes for breadth-first ALTO download

### DIFF
--- a/harvester/file.py
+++ b/harvester/file.py
@@ -174,15 +174,13 @@ class ALTOFile(File):
         :type dc_identifier: String
         """
         href_filename = self.location_xlink.rsplit("/", maxsplit=1)[-1]
-        if not re.match(r"^0+([1-9]+0*)+.xml$", href_filename):
-            try:
-                href_filename = (
-                    f"{re.search(r'([1-9]+0*)+', href_filename).group(0)}.xml"
-                )
-            except AttributeError:
-                raise AttributeError(
-                    f"ALTO filename {href_filename} does not follow the accepted convention."
-                )
+        # if not re.match(r"^0+([1-9]+0*)+.xml$", href_filename):
+        try:
+            href_filename = f"{re.search(r'([1-9]+0*)+', href_filename).group(0)}.xml"
+        except AttributeError:
+            raise AttributeError(
+                f"ALTO filename {href_filename} does not follow the accepted convention."
+            )
         return f"{self.binding_dc_identifier}/page-{href_filename}"
 
     def _default_file_dir(self):

--- a/harvester/file.py
+++ b/harvester/file.py
@@ -174,7 +174,6 @@ class ALTOFile(File):
         :type dc_identifier: String
         """
         href_filename = self.location_xlink.rsplit("/", maxsplit=1)[-1]
-        # if not re.match(r"^0+([1-9]+0*)+.xml$", href_filename):
         try:
             href_filename = f"{re.search(r'([1-9]+0*)+', href_filename).group(0)}.xml"
         except AttributeError:

--- a/pipeline/dags/download_all_altos.py
+++ b/pipeline/dags/download_all_altos.py
@@ -27,7 +27,7 @@ default_args = {
 
 
 with DAG(
-    dag_id="download_all_sets_to_puhti",
+    dag_id="download_all_altos_to_puhti",
     schedule="@once",
     catchup=False,
     default_args=default_args,

--- a/pipeline/dags/download_all_altos.py
+++ b/pipeline/dags/download_all_altos.py
@@ -1,0 +1,66 @@
+"""
+Download all ALTO files from NLF to Puhti, when METS files have already been downloaded.
+"""
+
+from datetime import timedelta
+
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from airflow.providers.http.sensors.http import HttpSensor
+
+from operators.custom_operators import (
+    SaveAltosForAllSetsSFTPOperator,
+    CreateConnectionOperator,
+)
+
+
+BASE_PATH = "/scratch/project_2006633/nlf-harvester/nlf_collections"
+
+default_args = {
+    "owner": "Kielipankki",
+    "start_date": "2022-10-01",
+    "retries": 4,
+    "retry_delay": timedelta(minutes=10),
+    "email": ["helmiina.hotti@csc.fi"],
+    "email_on_failure": True,
+}
+
+
+with DAG(
+    dag_id="download_all_sets_to_puhti",
+    schedule="@once",
+    catchup=False,
+    default_args=default_args,
+    doc_md=__doc__,
+) as dag:
+
+    start = EmptyOperator(task_id="start")
+
+    create_nlf_connection = CreateConnectionOperator(
+        task_id="create_nlf_connection",
+        conn_id="nlf_http_conn",
+        conn_type="HTTP",
+        host="https://digi.kansalliskirjasto.fi/interfaces/OAI-PMH",
+        schema="HTTPS",
+    )
+
+    check_api_availability = HttpSensor(
+        task_id="check_api_availability", http_conn_id="nlf_http_conn", endpoint="/"
+    )
+
+    save_all_alto_files = SaveAltosForAllSetsSFTPOperator(
+        task_id="save_all_alto_files",
+        http_conn_id="nlf_http_conn",
+        ssh_conn_id="puhti_conn",
+        base_path=BASE_PATH,
+    )
+
+    success = EmptyOperator(task_id="success")
+
+    (
+        start
+        >> create_nlf_connection
+        >> check_api_availability
+        >> save_all_alto_files
+        >> success
+    )

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -221,9 +221,7 @@ class SaveMetsForAllSetsSFTPOperator(BaseOperator):
             for set_id in [
                 s
                 for s in list(api.set_ids())
-                if not s.startswith(
-                    ("col-501", "col-82", "col-25", "col-101", "sanomalehti")
-                )
+                if not s.startswith(("col-501", "col-82", "col-25", "col-101"))
                 and not s.endswith("rajatut")
             ]:
                 self.log.info(f"Downloading METS files for set {set_id}")

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -264,7 +264,14 @@ class SaveAltosForMetsSFTPOperator(BaseOperator):
         path = os.path.join(
             self.mets_path, f"{utils.binding_id_from_dc(self.dc_identifier)}_METS.xml"
         )
-        mets = METS(self.dc_identifier, self.sftp_client.file(path, "r"))
+        try:
+            mets = METS(self.dc_identifier, self.sftp_client.file(path, "r"))
+        except IOError:
+            self.log.error(
+                f"No METS found for binding {utils.binding_id_from_dc(self.dc_identifier)}"
+            )
+            return
+
         alto_files = peekable(mets.files_of_type(ALTOFile))
 
         first_alto = alto_files.peek()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,7 +159,7 @@ def alto_filename():
     """
     Return the filename for an ALTO test file
     """
-    return "00002.xml"
+    return "2.xml"
 
 
 @pytest.fixture
@@ -221,10 +221,10 @@ def mock_alto_download(alto_url, alto_filename):
 def url_matcher(request):
     url = request.url
     mock_urls = [
-        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/379973/page-00001.xml",
-        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/379973/page-00002.xml",
-        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/379973/page-00003.xml",
-        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/379973/page-00004.xml",
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/379973/page-1.xml",
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/379973/page-2.xml",
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/379973/page-3.xml",
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/379973/page-4.xml",
     ]
     return url in mock_urls
 


### PR DESCRIPTION
I will add necessary hacks to make ALTO download possible as I encounter more issues.
ALTO filename creation is also updated based on new information from NLF (all filenames in ALTO download URLs are of type `n.xml`, so no preceding zeros need to be preserved, which simplified the code a bit.