### PR TITLE
KP-6842 Skip download of existing non-empty files

### DIFF
--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -172,7 +172,7 @@ class SaveFilesSFTPOperator(BaseOperator):
             "execute() must be defined separately for each file type."
         )
 
-    def check_if_file_exists(self, path):
+    def file_exists(self, path):
         """
         Check if a non-empty file already exists in the given path.
 
@@ -208,7 +208,7 @@ class SaveMetsSFTPOperator(SaveFilesSFTPOperator):
             )
         )
 
-        if self.check_if_file_exists(output_file):
+        if self.file_exists(output_file):
             return
 
         self.ensure_tmp_output_location()
@@ -280,7 +280,7 @@ class SaveAltosSFTPOperator(SaveFilesSFTPOperator):
                 )
             )
 
-            if self.check_if_file_exists(output_file):
+            if self.file_exists(output_file):
                 continue
 
             temp_output_file = str(


### PR DESCRIPTION
Before METS or ALTO files are downloaded, it is checked if a non-empty file already exists in the path. Checking if the file exists already and skipping its download is 20-30% faster than redownloading the file.

Temporary code in `parallel_download` where DC identifiers for a set are read from a file is now commented out thanks to fixes to the NLF API. 