### PR TITLE
KP-7021 Construct subdirectory structure

### DIFF
--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -88,7 +88,7 @@ def construct_dir_structure(
 ):
     """
     Construct and return a subdirectory structure of given depth
-    for a binding.
+    for a binding. Default depth is the length of the binding ID.
 
     :param binding_id: Binding id
     :type binding_id: str
@@ -102,6 +102,7 @@ def construct_dir_structure(
     if not depth:
         depth = len(binding_id)
     sub_dirs = [f"{binding_id[:i]}/" for i in range(1, depth+1)]
+    sub_dirs.append(binding_id)
     binding_path = f'{base_path}/{set_id}/{"".join(sub_dirs)}'
     return binding_path
 

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -35,7 +35,7 @@ def make_intermediate_dirs(sftp_client, remote_directory):
             continue
 
 
-def construct_file_download_location(
+def file_download_location(
     file, base_path=None, file_dir=None, filename=None
 ):
     """
@@ -59,7 +59,7 @@ def construct_file_download_location(
     return Path(base_path) / Path(file_dir) / Path(filename)
 
 
-def construct_mets_download_location(
+def mets_download_location(
     dc_identifier, base_path=None, file_dir=None, filename=None
 ):
     """
@@ -83,8 +83,8 @@ def construct_mets_download_location(
     return Path(base_path) / Path(file_dir) / Path(filename)
 
 
-def construct_dir_structure(
-        binding_id, base_path, set_id, depth=None
+def binding_download_location(
+        binding_id, set_id, depth=None
 ):
     """
     Construct and return a subdirectory structure of given depth
@@ -92,8 +92,6 @@ def construct_dir_structure(
 
     :param binding_id: Binding id
     :type binding_id: str
-    :param base_path: Base path of download location (e.g. project folder in Puhti)
-    :type base_path: str
     :param set_id: Collection ID to which the binding belongs to
     :type set_id: str
     :param depth: Depth of the subdirectory structure (defaults to length of binding ID)
@@ -101,9 +99,9 @@ def construct_dir_structure(
     """
     if not depth:
         depth = len(binding_id)
-    sub_dirs = [f"{binding_id[:i]}/" for i in range(1, depth+1)]
+    sub_dirs = [f"{binding_id[:i]}" for i in range(1, depth+1)]
     sub_dirs.append(binding_id)
-    binding_path = f'{base_path}/{set_id}/{"".join(sub_dirs)}'
+    binding_path = os.path.join(set_id, *sub_dirs)
     return binding_path
 
 

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -83,6 +83,29 @@ def construct_mets_download_location(
     return Path(base_path) / Path(file_dir) / Path(filename)
 
 
+def construct_dir_structure(
+        binding_id, base_path, set_id, depth=None
+):
+    """
+    Construct and return a subdirectory structure of given depth
+    for a binding.
+
+    :param binding_id: Binding id
+    :type binding_id: str
+    :param base_path: Base path of download location (e.g. project folder in Puhti)
+    :type base_path: str
+    :param set_id: Collection ID to which the binding belongs to
+    :type set_id: str
+    :param depth: Depth of the subdirectory structure (defaults to length of binding ID)
+    :type depth: int
+    """
+    if not depth:
+        depth = len(binding_id)
+    sub_dirs = [f"{binding_id[:i]}/" for i in range(1, depth+1)]
+    binding_path = f'{base_path}/{set_id}/{"".join(sub_dirs)}'
+    return binding_path
+
+
 def calculate_batch_size(col_size):
     """
     Return a suitable download batch size for a collection.

--- a/harvester_cli.py
+++ b/harvester_cli.py
@@ -119,7 +119,7 @@ def download_files_from(mets_file_path, collection_dc_identifier, encoding, base
     mets = METS(collection_dc_identifier, mets_file=open(mets_file_path, "rb"), encoding=encoding)
     for file in mets.files():
         try:
-            output_file_path = utils.construct_file_download_location(
+            output_file_path = utils.file_download_location(
                 file=file, base_path=base_path
             )
             output_file_path.parent.mkdir(parents=True, exist_ok=True)

--- a/pipeline/dags/parallel_batch_download.py
+++ b/pipeline/dags/parallel_batch_download.py
@@ -82,32 +82,32 @@ for set_id in SET_IDS:
 
                     for dc_identifier in batch:
                         binding_id = utils.binding_id_from_dc(dc_identifier)
-                        base_path = os.path.join(BASE_PATH, utils.binding_download_location(binding_id, set_id))
-                        tmp_base_path = os.path.join(TMPDIR, utils.binding_download_location(binding_id, set_id))
+                        binding_path = os.path.join(BASE_PATH, utils.binding_download_location(binding_id, set_id))
+                        tmp_binding_path = os.path.join(TMPDIR, utils.binding_download_location(binding_id, set_id))
 
                         SaveMetsSFTPOperator(
                             task_id=f"save_mets_{binding_id}",
                             api=api,
                             sftp_client=sftp_client,
                             ssh_client=ssh_client,
-                            tmpdir=tmp_base_path,
+                            tmpdir=tmp_binding_path,
                             dc_identifier=dc_identifier,
-                            base_path=base_path,
+                            binding_path=binding_path,
                             file_dir="mets",
                         ).execute(context={})
 
                         SaveAltosSFTPOperator(
                             task_id=f"save_altos_{binding_id}",
-                            mets_path=f"{base_path}/mets",
+                            mets_path=f"{binding_path}/mets",
                             sftp_client=sftp_client,
                             ssh_client=ssh_client,
-                            tmpdir=tmp_base_path,
+                            tmpdir=tmp_binding_path,
                             dc_identifier=dc_identifier,
-                            base_path=base_path,
+                            binding_path=binding_path,
                             file_dir="alto",
                         ).execute(context={})
 
-                        ssh_client.exec_command(f"rm -r {tmp_base_path}")
+                        ssh_client.exec_command(f"rm -r {tmp_binding_path}")
 
             with open(BINDING_BASE_PATH / set_id / "binding_ids", "r") as f:
                 bindings = f.read().splitlines()

--- a/pipeline/dags/parallel_batch_download.py
+++ b/pipeline/dags/parallel_batch_download.py
@@ -5,6 +5,7 @@ Collections are split into batches based on their size.
 
 from datetime import timedelta
 from pathlib import Path
+import os
 
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.http.sensors.http import HttpSensor
@@ -81,12 +82,8 @@ for set_id in SET_IDS:
 
                     for dc_identifier in batch:
                         binding_id = utils.binding_id_from_dc(dc_identifier)
-                        base_path = utils.construct_dir_structure(
-                            binding_id, BASE_PATH, set_id
-                        )
-                        tmp_base_path = utils.construct_dir_structure(
-                            binding_id, TMPDIR, set_id
-                        )
+                        base_path = os.path.join(BASE_PATH, utils.binding_download_location(binding_id, set_id))
+                        tmp_base_path = os.path.join(TMPDIR, utils.binding_download_location(binding_id, set_id))
 
                         SaveMetsSFTPOperator(
                             task_id=f"save_mets_{binding_id}",

--- a/pipeline/dags/parallel_batch_download.py
+++ b/pipeline/dags/parallel_batch_download.py
@@ -81,8 +81,12 @@ for set_id in SET_IDS:
 
                     for dc_identifier in batch:
                         binding_id = utils.binding_id_from_dc(dc_identifier)
-                        base_path = utils.construct_dir_structure(binding_id, BASE_PATH, set_id)
-                        tmp_base_path = utils.construct_dir_structure(binding_id, TMPDIR, set_id)
+                        base_path = utils.construct_dir_structure(
+                            binding_id, BASE_PATH, set_id
+                        )
+                        tmp_base_path = utils.construct_dir_structure(
+                            binding_id, TMPDIR, set_id
+                        )
 
                         SaveMetsSFTPOperator(
                             task_id=f"save_mets_{binding_id}",
@@ -108,9 +112,7 @@ for set_id in SET_IDS:
 
                         ssh_client.exec_command(f"rm -r {tmp_base_path}")
 
-            with open(
-                BINDING_BASE_PATH / set_id / "binding_ids", "r"
-            ) as f:
+            with open(BINDING_BASE_PATH / set_id / "binding_ids", "r") as f:
                 bindings = f.read().splitlines()
 
             for batch in utils.split_into_batches(bindings):
@@ -124,9 +126,7 @@ for set_id in SET_IDS:
 
         (
             begin_download
-            >> download_set(
-                set_id=set_id, api=api, ssh_conn_id=SSH_CONN_ID
-            )
+            >> download_set(set_id=set_id, api=api, ssh_conn_id=SSH_CONN_ID)
             >> clear_temp_dir()
         )
 

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -66,7 +66,7 @@ class SaveMetsOperator(BaseOperator):
         http_conn = BaseHook.get_connection(self.http_conn_id)
         api = PMH_API(url=http_conn.host)
         output_file = str(
-            utils.construct_mets_download_location(
+            utils.mets_download_location(
                 dc_identifier=self.dc_identifier,
                 base_path=self.base_path,
                 file_dir="mets",
@@ -99,7 +99,7 @@ class SaveAltosOperator(BaseOperator):
         mets = METS(self.dc_identifier, open(path, "rb"))
         alto_files = mets.files_of_type(ALTOFile)
         for alto_file in alto_files:
-            output_file = utils.construct_file_download_location(
+            output_file = utils.file_download_location(
                 file=alto_file, base_path=self.base_path
             )
             output_file.parent.mkdir(parents=True, exist_ok=True)
@@ -201,7 +201,7 @@ class SaveMetsSFTPOperator(SaveFilesSFTPOperator):
 
     def execute(self, context):
         output_file = str(
-            utils.construct_mets_download_location(
+            utils.mets_download_location(
                 dc_identifier=self.dc_identifier,
                 base_path=self.base_path,
                 file_dir=self.file_dir,
@@ -214,7 +214,7 @@ class SaveMetsSFTPOperator(SaveFilesSFTPOperator):
         self.ensure_tmp_output_location()
 
         temp_output_file = str(
-            utils.construct_mets_download_location(
+            utils.mets_download_location(
                 dc_identifier=self.dc_identifier,
                 base_path=self.tmpdir,
                 file_dir=self.file_dir,
@@ -273,7 +273,7 @@ class SaveAltosSFTPOperator(SaveFilesSFTPOperator):
 
         for alto_file in alto_files:
             output_file = str(
-                utils.construct_file_download_location(
+                utils.file_download_location(
                     file=alto_file,
                     base_path=self.base_path,
                     file_dir=self.file_dir,
@@ -284,7 +284,7 @@ class SaveAltosSFTPOperator(SaveFilesSFTPOperator):
                 continue
 
             temp_output_file = str(
-                utils.construct_file_download_location(
+                utils.file_download_location(
                     file=alto_file, base_path=self.tmpdir, file_dir=self.file_dir
                 )
             )

--- a/tests/harvester/test_file.py
+++ b/tests/harvester/test_file.py
@@ -66,7 +66,7 @@ def test_download_to_default_path(
     """
     Test downloading an ALTO file to the default location.
     """
-    output_path = utils.construct_file_download_location(file=alto_file)
+    output_path = utils.file_download_location(file=alto_file)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(output_path, "wb") as output_file:

--- a/tests/harvester/test_pmh_interface.py
+++ b/tests/harvester/test_pmh_interface.py
@@ -42,7 +42,7 @@ def test_fetch_mets_with_custom_path(
     """
     api = PMH_API(oai_pmh_api_url)
     output_file = str(
-        utils.construct_mets_download_location(
+        utils.mets_download_location(
             dc_identifier=mets_dc_identifier,
             base_path=tmp_path,
             file_dir="mets",
@@ -66,7 +66,7 @@ def test_fetch_mets_with_default_path(
     api = PMH_API(oai_pmh_api_url)
     binding_id = utils.binding_id_from_dc(mets_dc_identifier)
     output_file = str(
-        utils.construct_mets_download_location(dc_identifier=mets_dc_identifier)
+        utils.mets_download_location(dc_identifier=mets_dc_identifier)
     )
     mocker.patch("builtins.open")
     with open(output_file, "wb") as mets_file:

--- a/tests/harvester/test_utils.py
+++ b/tests/harvester/test_utils.py
@@ -50,15 +50,15 @@ def test_split_into_batches():
     ]
 
 
-def test_construct_dir_structure():
+def test_binding_download_location():
     """
     Test that subdirectory structure is created correctly
     """
     binding_id = "123456"
-    dir_structure = utils.construct_dir_structure(binding_id, "/base", "col-123")
-    assert dir_structure == "/base/col-123/1/12/123/1234/12345/123456/123456"
+    dir_structure = utils.binding_download_location(binding_id, "col-123")
+    assert dir_structure == "col-123/1/12/123/1234/12345/123456/123456"
 
-    dir_structure_set_depth = utils.construct_dir_structure(
-        binding_id, "/base", "col-123", 3
+    dir_structure_set_depth = utils.binding_download_location(
+        binding_id, "col-123", 3
     )
-    assert dir_structure_set_depth == "/base/col-123/1/12/123/123456"
+    assert dir_structure_set_depth == "col-123/1/12/123/123456"

--- a/tests/harvester/test_utils.py
+++ b/tests/harvester/test_utils.py
@@ -48,3 +48,15 @@ def test_split_into_batches():
         [30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
         [40, 41, 42, 43, 44, 45, 46, 47, 48, 49],
     ]
+
+
+def test_construct_dir_structure():
+    """
+    Test that subdirectory structure is created correctly
+    """
+    binding_id = "123456"
+    dir_structure = utils.construct_dir_structure(binding_id, "/base", "col-123")
+    assert dir_structure == "/base/col-123/1/12/123/1234/12345/123456/123456"
+
+    dir_structure_set_depth = utils.construct_dir_structure(binding_id, "/base", "col-123", 3)
+    assert dir_structure_set_depth == "/base/col-123/1/12/123/123456"

--- a/tests/harvester/test_utils.py
+++ b/tests/harvester/test_utils.py
@@ -58,5 +58,7 @@ def test_construct_dir_structure():
     dir_structure = utils.construct_dir_structure(binding_id, "/base", "col-123")
     assert dir_structure == "/base/col-123/1/12/123/1234/12345/123456/123456"
 
-    dir_structure_set_depth = utils.construct_dir_structure(binding_id, "/base", "col-123", 3)
+    dir_structure_set_depth = utils.construct_dir_structure(
+        binding_id, "/base", "col-123", 3
+    )
     assert dir_structure_set_depth == "/base/col-123/1/12/123/123456"

--- a/tests/pipeline/test_custom_operators.py
+++ b/tests/pipeline/test_custom_operators.py
@@ -46,7 +46,7 @@ def test_save_mets_operator(mets_dc_identifier, expected_mets_response, tmp_path
         task_id="test_save_mets_task",
         http_conn_id="nlf_http_conn",
         dc_identifier=mets_dc_identifier,
-        base_path=tmp_path,
+        binding_path=tmp_path,
     )
 
     operator.execute(context={})
@@ -69,7 +69,7 @@ def test_save_altos_operator(
     alto_operator = SaveAltosOperator(
         task_id="test_save_altos_locally",
         dc_identifier=mets_dc_identifier,
-        base_path=tmp_path,
+        binding_path=tmp_path,
         mets_path="tests/data",
     )
 
@@ -118,7 +118,7 @@ def test_existing_mets_not_downloaded_again(
             ssh_client=ssh_client,
             tmpdir=temp_path,
             dc_identifier=mets_dc_identifier,
-            base_path=output_path,
+            binding_path=output_path,
             file_dir="file_dir",
         )
 
@@ -154,7 +154,7 @@ def test_save_mets_sftp_operator(
             ssh_client=ssh_client,
             tmpdir=temp_path,
             dc_identifier=mets_dc_identifier,
-            base_path=output_path,
+            binding_path=output_path,
             file_dir="file_dir",
         )
 
@@ -189,7 +189,7 @@ def test_empty_mets(
             ssh_client=ssh_client,
             tmpdir=temp_path,
             dc_identifier=empty_mets_dc_identifier,
-            base_path=output_path,
+            binding_path=output_path,
             file_dir="file_dir",
         )
 
@@ -222,7 +222,7 @@ def test_failed_mets_request(
             ssh_client=ssh_client,
             tmpdir=temp_path,
             dc_identifier=failed_mets_dc_identifier,
-            base_path=output_path,
+            binding_path=output_path,
             file_dir="file_dir",
         )
 
@@ -261,7 +261,7 @@ def test_save_altos_sftp_operator(
             task_id="test_save_altos_remote",
             sftp_client=sftp,
             ssh_client=ssh_client,
-            base_path=output_path,
+            binding_path=output_path,
             tmpdir=temp_path,
             file_dir="sub_dir",
             mets_path=f"{output_path}/sub_dir/mets",
@@ -317,7 +317,7 @@ def test_existing_altos_not_downloaded_again(
             task_id="test_save_altos_remote",
             sftp_client=sftp,
             ssh_client=ssh_client,
-            base_path=output_path,
+            binding_path=output_path,
             tmpdir=temp_path,
             file_dir="sub_dir",
             mets_path=f"{output_path}/sub_dir/mets",


### PR DESCRIPTION
Directory structure for downloaded bindings is now as follows (for binding `1911598` in `col-361`):
`col-361/1/19/191/1911/19115/191159/1911598/1911598`.

Another depth for the directory structure can be set as well (e.g. 3):
`col-361/1/19/191/1911598`