### PR TITLE
KP-7389 Download individual files to fast local disk instead of lustre

### DIFF
--- a/pipeline/dags/download_images.py
+++ b/pipeline/dags/download_images.py
@@ -10,13 +10,17 @@ from airflow.operators.empty import EmptyOperator
 from airflow.hooks.base import BaseHook
 from airflow.decorators import dag
 
-from includes.tasks import check_if_download_should_begin, download_set, clear_temp_dir
+from includes.tasks import (
+    check_if_download_should_begin,
+    download_set,
+    clear_temporary_directory,
+)
 from harvester.pmh_interface import PMH_API
 
 INITIAL_DOWNLOAD = True
 
 BASE_PATH = Path("/scratch/project_2006633/nlf-harvester/images")
-TMPDIR = Path("/local_scratch/robot_2006633_puhti/harvester-temp")
+TMPDIR = Path("/local_scratch/robot_2006633_puhti/harvester")
 IMAGE_SPLIT_DIR = Path("/home/ubuntu/image_split/")
 BINDING_BASE_PATH = Path("/home/ubuntu/binding_ids_all")
 SSH_CONN_ID = "puhti_conn"
@@ -77,7 +81,7 @@ for col in COLLECTIONS:
                 base_path=BASE_PATH,
                 tmpdir=TMPDIR,
             )
-            >> clear_temp_dir(SSH_CONN_ID, TMPDIR)
+            >> clear_temporary_directory(SSH_CONN_ID, TMPDIR)
         )
 
     download_dag()

--- a/pipeline/dags/download_images.py
+++ b/pipeline/dags/download_images.py
@@ -13,7 +13,6 @@ from airflow.decorators import dag
 from includes.tasks import check_if_download_should_begin, download_set, clear_temp_dir
 from harvester.pmh_interface import PMH_API
 
-
 INITIAL_DOWNLOAD = True
 
 BASE_PATH = Path("/scratch/project_2006633/nlf-harvester/images")
@@ -25,8 +24,8 @@ HTTP_CONN_ID = "nlf_http_conn"
 COLLECTIONS = [
     {"id": "col-361", "image_size": 150},
     {"id": "col-501", "image_size": 5000},
-    #    {"id": "col-82", "image_size": 150000},
-    #    {"id": "col-24", "image_size": 100000},
+    {"id": "col-82", "image_size": 150000},
+    {"id": "col-24", "image_size": 100000},
 ]
 
 default_args = {

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -74,6 +74,7 @@ def download_set(
                     task_id=f"prepare_download_location_{image_base_name}",
                     trigger_rule="none_skipped",
                     ssh_conn_id=ssh_conn_id,
+                    tmp_path=tmpdir,
                     base_path=base_path,
                     image_base_name=image_base_name,
                 )
@@ -82,6 +83,7 @@ def download_set(
                     task_id=f"create_image_{image_base_name}",
                     trigger_rule="none_skipped",
                     ssh_conn_id=ssh_conn_id,
+                    tmp_path=tmpdir,
                     base_path=base_path,
                     image_base_name=image_base_name,
                 )
@@ -92,7 +94,6 @@ def download_set(
                         task_id="download_binding_batch",
                         trigger_rule="none_skipped",
                         ssh_conn_id=ssh_conn_id,
-                        base_path=base_path,
                         image_base_name=image_base_name,
                         tmpdir=tmpdir,
                         api=api,

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -22,8 +22,11 @@ def check_if_download_should_begin(set_id, binding_base_path, http_conn_id):
 
     def newest_dag_run():
         dag_runs = DagRun.find(dag_id=f"image_download_{set_id}", state="running")
-        dag_runs.sort(key=lambda x: x.execution_date, reverse=True)
-        return dag_runs[0]
+        newest = dag_runs[0]
+        for dag_run in dag_runs[1:]:
+            if dag_run.execution_date > newest.execution_date:
+                newest = dag_run
+        return newest
 
     try:
         api_ok = HttpSensor(

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -129,8 +129,8 @@ def download_set(
             image_downloads.append(image_download_tg)
 
 
-@task(task_id="clear_temp_directory", trigger_rule="all_done")
-def clear_temp_dir(ssh_conn_id, tmpdir):
+@task(task_id="clear_temporary_directory", trigger_rule="all_done")
+def clear_temporary_directory(ssh_conn_id, tmpdir):
     ssh_hook = SSHHook(ssh_conn_id=ssh_conn_id)
     with ssh_hook.get_conn() as ssh_client:
         ssh_client.exec_command(f"rm -r {tmpdir}/*")

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -1,5 +1,3 @@
-from urllib.error import HTTPError
-
 from airflow.decorators import task, task_group
 from airflow.providers.http.sensors.http import HttpSensor
 from airflow.providers.ssh.hooks.ssh import SSHHook

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -384,7 +384,7 @@ class CreateImageOperator(BaseOperator):
         self.tmp_path = tmp_path
 
     def execute(self, context):
-        tmp_image_path = self.tmp_path / self.image_base_name
+        tmp_image_data_source = self.tmp_path / self.image_base_name
         final_image_location = self.base_path / (self.image_base_name + ".sqfs")
         temporary_image_location = final_image_location.with_suffix(".sqfs.tmp")
 
@@ -394,7 +394,7 @@ class CreateImageOperator(BaseOperator):
                 "Creating temporary image in %s on Puhti", temporary_image_location
             )
             _, stdout, stderr = ssh_client.exec_command(
-                f"mksquashfs {tmp_image_path} {temporary_image_location}"
+                f"mksquashfs {tmp_image_data_source} {temporary_image_location}"
             )
 
             self.log.info("Deleting old image %s on Puhti", final_image_location)
@@ -413,4 +413,4 @@ class CreateImageOperator(BaseOperator):
                     f"Creation of image {final_image_location} failed: "
                     f"{stderr.read().decode('utf-8')}"
                 )
-            ssh_client.exec_command(f"rm -r {tmp_image_path}")
+            ssh_client.exec_command(f"rm -r {tmp_image_data_source}")

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -437,8 +437,15 @@ class CreateImageOperator(BaseOperator):
                     f"mksquashfs {tmp_image_data_source} {temporary_image_location}",
                 )
 
-                self.log.info("Deleting old image %s on Puhti", final_image_location)
-                sftp_client.remove(str(final_image_location))
+                self.log.info(
+                    "Attempting deletion of old image %s on Puhti", final_image_location
+                )
+                try:
+                    sftp_client.remove(str(final_image_location))
+                except FileNotFoundError:
+                    self.log.info("Old image not present, no removal needed")
+                else:
+                    self.log.info("Old image removed")
 
                 self.log.info(
                     "Moving temporary image %s to final location %s on Puhti",

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -245,7 +245,6 @@ class DownloadBindingBatchOperator(BaseOperator):
 
     :param batch: a list of DC identifiers
     :param ssh_conn_id: SSH connection id
-    :param base_path: Base path for images
     :param image_base_name: Name for disk image
     :param tmpdir: Absolute path for a temporary directory on the remote server
     :param api: OAI-PMH api
@@ -255,7 +254,6 @@ class DownloadBindingBatchOperator(BaseOperator):
         self,
         batch,
         ssh_conn_id,
-        base_path,
         image_base_name,
         tmpdir,
         api,

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -341,7 +341,7 @@ class PrepareDownloadLocationOperator(BaseOperator):
 
     def execute(self, context):
         tmp_image_path = self.tmp_path / self.image_base_name
-        image_dir_path = self.base_path / self.image_base_name
+        image_dir_path = self.base_path
 
         ssh_hook = SSHHook(ssh_conn_id=self.ssh_conn_id)
         with ssh_hook.get_conn() as ssh_client:

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -389,6 +389,8 @@ class CreateImageOperator(BaseOperator):
         """
         _, stdout, stderr = ssh_client.exec_command(command)
 
+        self.log.debug(stdout)
+
         exit_code = stdout.channel.recv_exit_status()
         if exit_code != 0:
             raise ImageCreationError(

--- a/tests/pipeline/test_custom_operators.py
+++ b/tests/pipeline/test_custom_operators.py
@@ -2,10 +2,16 @@ import pytest
 import os
 from pathlib import Path
 from airflow import settings
+from airflow.models import Connection
+from requests.exceptions import RequestException
 
 from harvester import utils
 from harvester.mets import METSFileEmptyError
-from pipeline.plugins.operators.custom_operators import *
+from pipeline.plugins.operators.custom_operators import (
+    CreateConnectionOperator,
+    SaveMetsSFTPOperator,
+    SaveAltosSFTPOperator,
+)
 from harvester.pmh_interface import PMH_API
 
 

--- a/tests/pipeline/test_custom_operators.py
+++ b/tests/pipeline/test_custom_operators.py
@@ -46,8 +46,8 @@ def test_existing_mets_not_downloaded_again(
     Test that existing METS files are not redownloaded.
     """
     api = PMH_API(oai_pmh_api_url)
-    temp_path = Path(sftp_server.root) / "tmp"
-    mets_dir = temp_path / "mets"
+    tmp_path = Path(sftp_server.root) / "tmp"
+    mets_dir = tmp_path / "mets"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
@@ -65,7 +65,7 @@ def test_existing_mets_not_downloaded_again(
             api=api,
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir=temp_path,
+            tmpdir=tmp_path,
             dc_identifier=mets_dc_identifier,
             file_dir="mets",
         )
@@ -78,11 +78,11 @@ def test_existing_mets_not_downloaded_again(
 
         # Check that the METS file was not downloaded to another location within
         # output_path either
-        files_in_output_path = sum(len(files) for _, _, files in os.walk(temp_path))
+        files_in_output_path = sum(len(files) for _, _, files in os.walk(tmp_path))
         assert files_in_output_path == 1
 
 
-def test_existing_tempfile_does_not_prevent_download(
+def test_existing_tmp_file_does_not_prevent_download(
     oai_pmh_api_url,
     mets_dc_identifier,
     sftp_server,
@@ -96,8 +96,8 @@ def test_existing_tempfile_does_not_prevent_download(
     executing it, and checking that the proper file has been created afterwards.
     """
     api = PMH_API(oai_pmh_api_url)
-    temp_path = Path(sftp_server.root) / "tmp"
-    mets_dir = temp_path / "mets"
+    tmp_path = Path(sftp_server.root) / "tmp"
+    mets_dir = tmp_path / "mets"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
@@ -112,12 +112,12 @@ def test_existing_tempfile_does_not_prevent_download(
             api=api,
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir=temp_path,
+            tmpdir=tmp_path,
             dc_identifier=mets_dc_identifier,
             file_dir="mets",
         )
 
-        tmpfile_path = sftp_mets_operator.tempfile_path(sftp_mets_operator.output_file)
+        tmpfile_path = sftp_mets_operator.tmp_path(sftp_mets_operator.output_file)
         with sftp.file(str(tmpfile_path), "w") as pre_existing_tmpfile:
             pre_existing_tmpfile.write("this should not prevent proper download")
 
@@ -139,7 +139,7 @@ def test_save_mets_sftp_operator(
     """
 
     api = PMH_API(oai_pmh_api_url)
-    temp_path = Path(sftp_server.root) / "tmp" / "sub" / "path"
+    tmp_path = Path(sftp_server.root) / "tmp" / "sub" / "path"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
@@ -149,14 +149,14 @@ def test_save_mets_sftp_operator(
             api=api,
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir=temp_path,
+            tmpdir=tmp_path,
             dc_identifier=mets_dc_identifier,
             file_dir="file_dir",
         )
 
         sftp_mets_operator.execute(context={})
 
-        with sftp.file(str(temp_path / "file_dir" / "379973_METS.xml"), "r") as file:
+        with sftp.file(str(tmp_path / "file_dir" / "379973_METS.xml"), "r") as file:
             assert file.read().decode("utf-8") == expected_mets_response
 
 
@@ -172,7 +172,7 @@ def test_empty_mets(
     """
 
     api = PMH_API(oai_pmh_api_url)
-    temp_path = Path(sftp_server.root) / "tmp" / "sub" / "path"
+    tmp_path = Path(sftp_server.root) / "tmp" / "sub" / "path"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
@@ -182,7 +182,7 @@ def test_empty_mets(
             api=api,
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir=temp_path,
+            tmpdir=tmp_path,
             dc_identifier=empty_mets_dc_identifier,
             file_dir="file_dir",
         )
@@ -203,7 +203,7 @@ def test_failed_mets_request(
     """
 
     api = PMH_API(oai_pmh_api_url)
-    temp_path = Path(sftp_server.root) / "tmp" / "sub" / "path"
+    tmp_path = Path(sftp_server.root) / "tmp" / "sub" / "path"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
@@ -213,7 +213,7 @@ def test_failed_mets_request(
             api=api,
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir=temp_path,
+            tmpdir=tmp_path,
             dc_identifier=failed_mets_dc_identifier,
             file_dir="file_dir",
         )
@@ -233,9 +233,9 @@ def test_save_altos_sftp_operator(
     Check that executing SaveAltosForMetsSFTPOperator correctly saves ALTO files
     to a remote server.
     """
-    temp_path = Path(sftp_server.root) / "tmp"
-    mets_dir = temp_path / "sub_dir" / "mets"
-    alto_dir = temp_path / "sub_dir" / "alto"
+    tmp_path = Path(sftp_server.root) / "tmp"
+    mets_dir = tmp_path / "sub_dir" / "mets"
+    alto_dir = tmp_path / "sub_dir" / "alto"
     mets_file = mets_dir / "379973_METS.xml"
 
     with ssh_server.client("user") as ssh_client:
@@ -254,7 +254,7 @@ def test_save_altos_sftp_operator(
             task_id="test_save_altos_remote",
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir=temp_path,
+            tmpdir=tmp_path,
             file_dir=alto_dir,
             mets_path=mets_dir,
             dc_identifier=mets_dc_identifier,
@@ -285,7 +285,7 @@ def test_existing_altos_not_downloaded_again(
     mets_dir = output_path / "sub_dir" / "mets"
     alto_dir = output_path / "sub_dir" / "alto"
     mets_file = mets_dir / "379973_METS.xml"
-    temp_path = Path(sftp_server.root) / "tmp"
+    tmp_path = Path(sftp_server.root) / "tmp"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
@@ -317,7 +317,7 @@ def test_existing_altos_not_downloaded_again(
             task_id="test_save_altos_remote",
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir=temp_path,
+            tmpdir=tmp_path,
             file_dir=alto_dir,
             mets_path=mets_dir,
             dc_identifier=mets_dc_identifier,

--- a/tests/pipeline/test_custom_operators.py
+++ b/tests/pipeline/test_custom_operators.py
@@ -1,18 +1,19 @@
-import pytest
 import os
 from pathlib import Path
+
 from airflow import settings
 from airflow.models import Connection
+import pytest
 from requests.exceptions import RequestException
 
 from harvester import utils
 from harvester.mets import METSFileEmptyError
+from harvester.pmh_interface import PMH_API
 from pipeline.plugins.operators.custom_operators import (
     CreateConnectionOperator,
     SaveMetsSFTPOperator,
     SaveAltosSFTPOperator,
 )
-from harvester.pmh_interface import PMH_API
 
 
 def test_create_connection_operator():

--- a/tests/pipeline/test_custom_operators.py
+++ b/tests/pipeline/test_custom_operators.py
@@ -132,7 +132,6 @@ def test_save_mets_sftp_operator(
     """
 
     api = PMH_API(oai_pmh_api_url)
-    output_path = Path(sftp_server.root) / "tmp" / "sub" / "path"
     temp_path = Path(sftp_server.root) / "tmp" / "sub" / "path"
 
     with ssh_server.client("user") as ssh_client:
@@ -197,7 +196,6 @@ def test_failed_mets_request(
     """
 
     api = PMH_API(oai_pmh_api_url)
-    output_path = Path(sftp_server.root) / "some" / "sub" / "path"
     temp_path = Path(sftp_server.root) / "tmp" / "sub" / "path"
 
     with ssh_server.client("user") as ssh_client:

--- a/tests/pipeline/test_custom_operators.py
+++ b/tests/pipeline/test_custom_operators.py
@@ -39,9 +39,8 @@ def test_existing_mets_not_downloaded_again(
     Test that existing METS files are not redownloaded.
     """
     api = PMH_API(oai_pmh_api_url)
-    output_path = Path(sftp_server.root) / "sub_dir" / "binding_dir"
-    mets_dir = output_path / "mets"
     temp_path = Path(sftp_server.root) / "tmp"
+    mets_dir = temp_path / "mets"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
@@ -61,7 +60,6 @@ def test_existing_mets_not_downloaded_again(
             ssh_client=ssh_client,
             tmpdir=temp_path,
             dc_identifier=mets_dc_identifier,
-            binding_path=output_path,
             file_dir="mets",
         )
 
@@ -73,7 +71,7 @@ def test_existing_mets_not_downloaded_again(
 
         # Check that the METS file was not downloaded to another location within
         # output_path either
-        files_in_output_path = sum(len(files) for _, _, files in os.walk(output_path))
+        files_in_output_path = sum(len(files) for _, _, files in os.walk(temp_path))
         assert files_in_output_path == 1
 
 
@@ -102,13 +100,12 @@ def test_save_mets_sftp_operator(
             ssh_client=ssh_client,
             tmpdir=temp_path,
             dc_identifier=mets_dc_identifier,
-            binding_path=output_path,
             file_dir="file_dir",
         )
 
         sftp_mets_operator.execute(context={})
 
-        with sftp.file(str(output_path / "file_dir" / "379973_METS.xml"), "r") as file:
+        with sftp.file(str(temp_path / "file_dir" / "379973_METS.xml"), "r") as file:
             assert file.read().decode("utf-8") == expected_mets_response
 
 
@@ -124,7 +121,6 @@ def test_empty_mets(
     """
 
     api = PMH_API(oai_pmh_api_url)
-    output_path = Path(sftp_server.root) / "some" / "sub" / "path"
     temp_path = Path(sftp_server.root) / "tmp" / "sub" / "path"
 
     with ssh_server.client("user") as ssh_client:
@@ -137,7 +133,6 @@ def test_empty_mets(
             ssh_client=ssh_client,
             tmpdir=temp_path,
             dc_identifier=empty_mets_dc_identifier,
-            binding_path=output_path,
             file_dir="file_dir",
         )
 
@@ -170,7 +165,6 @@ def test_failed_mets_request(
             ssh_client=ssh_client,
             tmpdir=temp_path,
             dc_identifier=failed_mets_dc_identifier,
-            binding_path=output_path,
             file_dir="file_dir",
         )
 
@@ -189,11 +183,10 @@ def test_save_altos_sftp_operator(
     Check that executing SaveAltosForMetsSFTPOperator correctly saves ALTO files
     to a remote server.
     """
-    output_path = Path(sftp_server.root) / "dir"
-    mets_dir = output_path / "sub_dir" / "mets"
-    alto_dir = output_path / "sub_dir" / "alto"
-    mets_file = mets_dir / "379973_METS.xml"
     temp_path = Path(sftp_server.root) / "tmp"
+    mets_dir = temp_path / "sub_dir" / "mets"
+    alto_dir = temp_path / "sub_dir" / "alto"
+    mets_file = mets_dir / "379973_METS.xml"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
@@ -211,7 +204,6 @@ def test_save_altos_sftp_operator(
             task_id="test_save_altos_remote",
             sftp_client=sftp,
             ssh_client=ssh_client,
-            binding_path=output_path,
             tmpdir=temp_path,
             file_dir=alto_dir,
             mets_path=mets_dir,
@@ -275,7 +267,6 @@ def test_existing_altos_not_downloaded_again(
             task_id="test_save_altos_remote",
             sftp_client=sftp,
             ssh_client=ssh_client,
-            binding_path=output_path,
             tmpdir=temp_path,
             file_dir=alto_dir,
             mets_path=mets_dir,

--- a/tests/pipeline/test_custom_operators.py
+++ b/tests/pipeline/test_custom_operators.py
@@ -28,12 +28,12 @@ def test_create_connection_operator():
     assert "nlf_http_conn" in conn_ids
 
 
+@pytest.mark.usefixtures("expected_mets_response")
 def test_existing_mets_not_downloaded_again(
     oai_pmh_api_url,
     mets_dc_identifier,
     sftp_server,
     ssh_server,
-    expected_mets_response,
 ):
     """
     Test that existing METS files are not redownloaded.
@@ -153,10 +153,10 @@ def test_save_mets_sftp_operator(
             assert file.read().decode("utf-8") == expected_mets_response
 
 
+@pytest.mark.usefixtures("empty_mets_response")
 def test_empty_mets(
     oai_pmh_api_url,
     empty_mets_dc_identifier,
-    empty_mets_response,
     sftp_server,
     ssh_server,
 ):
@@ -184,10 +184,10 @@ def test_empty_mets(
             sftp_mets_operator.execute(context={})
 
 
+@pytest.mark.usefixtures("failed_mets_response")
 def test_failed_mets_request(
     oai_pmh_api_url,
     failed_mets_dc_identifier,
-    failed_mets_response,
     sftp_server,
     ssh_server,
 ):
@@ -264,11 +264,11 @@ def test_save_altos_sftp_operator(
                 assert alto.read().decode("utf-8") == mock_alto_download_for_test_mets
 
 
+@pytest.mark.usefixtures("mock_alto_download_for_test_mets")
 def test_existing_altos_not_downloaded_again(
     mets_dc_identifier,
     sftp_server,
     ssh_server,
-    mock_alto_download_for_test_mets,
     simple_mets_path,
 ):
     """


### PR DESCRIPTION
This PR reduces the load on Lustre and improves disk image creation performance by downloading the individual files to `local_scratch` instead of `scratch` on Puhti. The resulting disk images are written directly to the final location on scratch because the quota on local_scratch is not sufficient.

There are also some other improvements, e.g. adding safeguards that prevent creating images that contain .tmp files. Details in commits and commit messages.