### PR TITLE
Allow provisioning DAGs only, and from a specific branch

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -25,7 +25,7 @@ ansible-galaxy install -r requirements.yml
 
 ## Source your cPouta (OpenStack) auth file.
 
-The [OpenStack auth file](https://docs.csc.fi/#cloud/pouta/install-client/#configure-your-terminal-environment-for-openstack) is necessary for provisioning the OpenStack resources. 
+The [OpenStack auth file](https://docs.csc.fi/#cloud/pouta/install-client/#configure-your-terminal-environment-for-openstack) is necessary for provisioning the OpenStack resources.
 
 ```
 $ source project_2006633-openrc.sh
@@ -37,4 +37,12 @@ $ source project_2006633-openrc.sh
 ansible-playbook -i inventories/dev harvesterPouta.yml
 ```
 
-Have your `kielipouta` password and `Kielipankki-passwords` GPG key password at hand, they may need to be inputted during provisioning. 
+Have your `kielipouta` password and `Kielipankki-passwords` GPG key password at hand, they may need to be inputted during provisioning.
+
+### Update DAGs only
+
+If you only wish to update the DAG files and their dependencies instead of a
+full provisioning, you can run
+```
+ansible-playbook harvesterPouta.yml -i inventories/dev --tags dag-update
+```

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -46,3 +46,9 @@ full provisioning, you can run
 ```
 ansible-playbook harvesterPouta.yml -i inventories/dev --tags dag-update
 ```
+
+If you have a specific branch/tag/SHA-1 you wish to use, you can provide that:
+
+```
+ansible-playbook harvesterPouta.yml -i inventories/dev --tags dag-update --extra-vars "harvester_branch=[KP-yourbranch]"
+```

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -7,6 +7,8 @@ project_key: "kielipouta"
 project_sg: "airflow-sg"
 project_security_groups: "default,{{ project_sg }}" # don't add spaces here!
 
+harvester_branch: "main"
+
 airflow_db_name: "airflow_db"
 airflow_db_user: "airflow"
 airflow_db_password: "{{ lookup('passwordstore', 'lb_passwords/airflow/db_password') }}"

--- a/ansible/roles/harvester-setup/tasks/main.yml
+++ b/ansible/roles/harvester-setup/tasks/main.yml
@@ -9,6 +9,7 @@
 - name: Clone kielipankki-nlf-harvester
   ansible.builtin.git:
     repo: "https://github.com/CSCfi/kielipankki-nlf-harvester.git"
+    version: "{{ harvester_branch }}"
     dest: "{{ harvester.path }}/"
     clone: yes
   tags:

--- a/ansible/roles/harvester-setup/tasks/main.yml
+++ b/ansible/roles/harvester-setup/tasks/main.yml
@@ -48,6 +48,18 @@
   tags:
     - dag-update
 
+- name: Restart Airflow services to ensure refreshing cached plugins when only updating DAGs
+  ansible.builtin.service:
+    name: "{{ item }}"
+    state: restarted
+  with_items:
+    - airflow-scheduler
+    - airflow-dagprocessor
+  become: yes
+  tags:
+    - never
+    - dag-update
+
 # The or-operator ("||") means that the latter part of the command (new
 # connection creation) is only executed if the former (grepping for puhti_conn
 # in pre-existing connections) fails (i.e. puhti_conn not found).

--- a/ansible/roles/harvester-setup/tasks/main.yml
+++ b/ansible/roles/harvester-setup/tasks/main.yml
@@ -3,22 +3,30 @@
     state: directory
     suffix: git
   register: harvester
+  tags:
+    - dag-update
 
 - name: Clone kielipankki-nlf-harvester
   ansible.builtin.git:
     repo: "https://github.com/CSCfi/kielipankki-nlf-harvester.git"
     dest: "{{ harvester.path }}/"
     clone: yes
+  tags:
+    - dag-update
 
 - name: Install required packages for harvester
   ansible.builtin.pip:
     requirements: "{{ harvester.path }}/requirements.txt"
   become: yes
+  tags:
+    - dag-update
 
 - name: Install required Airflow packages for harvester pipeline
   ansible.builtin.pip:
     requirements: "{{ harvester.path }}/pipeline/requirements.txt"
   become: yes
+  tags:
+    - dag-update
 
 - name: Copy dags and plugins from harvester to airflow directory
   ansible.builtin.copy:
@@ -28,12 +36,16 @@
   with_items:
     - dags
     - plugins
+  tags:
+    - dag-update
 
 - name: Copy harvester files to airflow plugins directory
   ansible.builtin.copy:
     src: "{{ harvester.path }}/harvester"
     dest: "{{ airflow_directory }}/plugins/"
     remote_src: yes
+  tags:
+    - dag-update
 
 # The or-operator ("||") means that the latter part of the command (new
 # connection creation) is only executed if the former (grepping for puhti_conn


### PR DESCRIPTION
To make testing changes easier on harvester-dev, added option to provision DAGs from a specific branch in GitHub. It is also now possible to only provision the DAGs, which speeds up the provisioning process and eliminates the need to provide password store credentials etc.