### PR TITLE
KP-7389 Refactoring before functional changes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,6 +6,7 @@ init-hook="from pylint.config import find_pylintrc; import os, sys; project_root
 
 [FORMAT]
 max-line-length=88
+good-names=i,j,k,e,ex,Run,_
 
 [MESSAGES CONTROL]
 # cell-var-from-loop: This works fine for generating Airflow tasks in loop

--- a/.pylintrc
+++ b/.pylintrc
@@ -6,3 +6,9 @@ init-hook="from pylint.config import find_pylintrc; import os, sys; project_root
 
 [FORMAT]
 max-line-length=88
+
+[MESSAGES CONTROL]
+# cell-var-from-loop: This works fine for generating Airflow tasks in loop
+# expression-not-assigned: False positives from '>>' operators in Airflow DAGs
+# pointless-statement: False positives from '>>' operators in Airflow DAGs
+disable=cell-var-from-loop,expression-not-assigned,pointless-statement

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,8 @@
+[MASTER]
+# Add some directories to pythonpath:
+# - pipeline/plugins because Airflow would add the corresponding directory to path
+# - project root, because that emulates harvester being found under plugins in provisioned Airflow machines
+init-hook="from pylint.config import find_pylintrc; import os, sys; project_root=os.path.dirname(find_pylintrc()); sys.path.append(project_root); sys.path.append(os.path.join(project_root, 'pipeline', 'plugins'))"
+
 [FORMAT]
 max-line-length=88

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -30,10 +30,11 @@ def make_intermediate_dirs(sftp_client, remote_directory):
     :param sftp_client: A Paramiko SFTP client.
     :param remote_directory: Absolute Path of the directory containing the file
     """
-    for i in range(1, len(remote_directory.split("/")) + 1):
-        remote_dir = "/".join(remote_directory.split("/")[:i])
+    remote_directory_parts = remote_directory.parts
+    for i in range(1, len(remote_directory_parts) + 1):
+        remote_dir = Path(*remote_directory_parts[:i])
         try:
-            sftp_client.mkdir(remote_dir)
+            sftp_client.mkdir(str(remote_dir))
         except IOError:
             continue
 
@@ -75,7 +76,7 @@ def mets_download_location(dc_identifier, base_path=None, file_dir=None, filenam
     if not base_path:
         base_path = Path(os.getcwd()) / "downloads"
     if not file_dir:
-        file_dir = f"{binding_id_from_dc(dc_identifier)}/mets"
+        file_dir = Path(binding_id_from_dc(dc_identifier)) / "mets"
     if not filename:
         filename = f"{binding_id_from_dc(dc_identifier)}_METS.xml"
 
@@ -182,7 +183,10 @@ def read_bindings(binding_base_path, set_id):
     Read and return a list of bindings from the latest binding ID file.
     """
     try:
-        binding_id_files = [datetime.strptime(fname.split("_")[-1], "%Y-%m-%d").date() for fname in os.listdir(binding_base_path / set_id)]
+        binding_id_files = [
+            datetime.strptime(fname.split("_")[-1], "%Y-%m-%d").date()
+            for fname in os.listdir(binding_base_path / set_id)
+        ]
     except FileNotFoundError:
         raise FileNotFoundError(f"No binding ID file found for set {set_id}")
     latest = max(binding_id_files)

--- a/pipeline/dags/download_images.py
+++ b/pipeline/dags/download_images.py
@@ -16,8 +16,8 @@ from harvester.pmh_interface import PMH_API
 
 INITIAL_DOWNLOAD = True
 
-BASE_PATH = "/scratch/project_2006633/nlf-harvester/images"
-TMPDIR = "/local_scratch/robot_2006633_puhti/harvester-temp"
+BASE_PATH = Path("/scratch/project_2006633/nlf-harvester/images")
+TMPDIR = Path("/local_scratch/robot_2006633_puhti/harvester-temp")
 IMAGE_SPLIT_DIR = Path("/home/ubuntu/image_split/")
 BINDING_BASE_PATH = Path("/home/ubuntu/binding_ids_all")
 SSH_CONN_ID = "puhti_conn"

--- a/pipeline/dags/download_single_binding.py
+++ b/pipeline/dags/download_single_binding.py
@@ -1,5 +1,6 @@
 """
-#### Debugging/testing DAG for downloading METS and ALTO files for a single binding to a remote server (Puhti).
+#### Debugging/testing DAG
+Downloads METS and ALTO files for a single binding to a remote server (Puhti).
 """
 
 from datetime import timedelta
@@ -20,10 +21,12 @@ from operators.custom_operators import (
     CreateConnectionOperator,
 )
 
-# DC_IDENTIFIER = "https://digi.kansalliskirjasto.fi/sanomalehti/binding/4699" # this fails
-DC_IDENTIFIER = (
-    "https://digi.kansalliskirjasto.fi/sanomalehti/binding/379973"  # this doesn't fail
-)
+# this fails
+# DC_IDENTIFIER = "https://digi.kansalliskirjasto.fi/sanomalehti/binding/4699"
+
+# this doesn't fail
+DC_IDENTIFIER = "https://digi.kansalliskirjasto.fi/sanomalehti/binding/379973"
+
 BASE_PATH = "/scratch/project_2006633/nlf-harvester/downloads/temp_test/"
 TMPDIR = "/local_scratch/robot_2006633_puhti/harvester-temp"
 SET_ID = "col-681"

--- a/pipeline/dags/fetch_binding_ids.py
+++ b/pipeline/dags/fetch_binding_ids.py
@@ -2,11 +2,10 @@
 DAG to fetch binding ids and save them to files.
 """
 
-from datetime import timedelta
-from pathlib import Path
-from datetime import date
-from sickle.oaiexceptions import NoRecordsMatch
+from datetime import date, timedelta
 import os
+from pathlib import Path
+from sickle.oaiexceptions import NoRecordsMatch
 
 from airflow.models import DagRun
 from airflow.hooks.base import BaseHook

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -89,7 +89,7 @@ def download_set(
                 (
                     prepare_download_location
                     >> DownloadBindingBatchOperator.partial(
-                        task_id=f"download_binding_batch",
+                        task_id="download_binding_batch",
                         trigger_rule="none_skipped",
                         ssh_conn_id=ssh_conn_id,
                         base_path=base_path,

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -1,8 +1,8 @@
+from urllib.error import HTTPError
+
 from airflow.decorators import task, task_group
 from airflow.providers.http.sensors.http import HttpSensor
 from airflow.providers.ssh.hooks.ssh import SSHHook
-
-from urllib.error import HTTPError
 
 from harvester import utils
 from operators.custom_operators import (
@@ -29,8 +29,8 @@ def check_if_download_should_begin(set_id, binding_base_path, http_conn_id):
         return "cancel_pipeline"
     if not api_ok:
         raise HTTPError("NLF API is not responding.")
-    else:
-        return "begin_download"
+
+    return "begin_download"
 
 
 @task_group(group_id="download_set")

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -168,7 +168,8 @@ class SaveMetsSFTPOperator(SaveFilesSFTPOperator):
                 )
             except OSError as e:
                 raise OSError(
-                    f"Writing METS {self.dc_identifier} to file failed with error number {e.errno}"
+                    f"Writing METS {self.dc_identifier} to file failed with error "
+                    f"number {e.errno}"
                 )
 
         self.ensure_final_output_location()
@@ -230,7 +231,8 @@ class SaveAltosSFTPOperator(SaveFilesSFTPOperator):
                     )
                 except RequestException as e:
                     self.log.error(
-                        f"ALTO download with URL {alto_file.download_url} failed: {e.response}"
+                        f"ALTO download with URL {alto_file.download_url} failed: "
+                        f"{e.response}"
                     )
                     continue
 
@@ -240,7 +242,8 @@ class SaveAltosSFTPOperator(SaveFilesSFTPOperator):
 
             if exit_status != 0:
                 self.log.error(
-                    f"Moving ALTO file {alto_file.download_url} from temp to destination failed"
+                    f"Moving ALTO file {alto_file.download_url} from temp to "
+                    "destination failed"
                 )
 
 
@@ -411,6 +414,7 @@ class CreateImageOperator(BaseOperator):
             )
             if stdout.channel.recv_exit_status() != 0:
                 raise Exception(
-                    f"Creation of image {image_dir_path}.sqfs failed: {stderr.read().decode('utf-8')}"
+                    f"Creation of image {image_dir_path}.sqfs failed: "
+                    f"{stderr.read().decode('utf-8')}"
                 )
             ssh_client.exec_command(f"rm -r {image_dir_path}")

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -33,7 +33,7 @@ class CreateConnectionOperator(BaseOperator):
         conn_ids = [conn.conn_id for conn in session.query(Connection).all()]
         if self.conn_id not in conn_ids:
             self.log.info(
-                f"Creating a new {self.conn_type} connection with ID {self.conn_id}"
+                "Creating a new %s connection with ID %s", self.conn_type, self.conn_id
             )
             conn = Connection(
                 conn_id=self.conn_id,
@@ -231,8 +231,9 @@ class SaveAltosSFTPOperator(SaveFilesSFTPOperator):
                     )
                 except RequestException as e:
                     self.log.error(
-                        f"ALTO download with URL {alto_file.download_url} failed: "
-                        f"{e.response}"
+                        "ALTO download with URL %s failed: %s",
+                        alto_file.download_url,
+                        e.response,
                     )
                     continue
 
@@ -242,8 +243,8 @@ class SaveAltosSFTPOperator(SaveFilesSFTPOperator):
 
             if exit_status != 0:
                 self.log.error(
-                    f"Moving ALTO file {alto_file.download_url} from temp to "
-                    "destination failed"
+                    "Moving ALTO file %s from temp to destination failed",
+                    alto_file.download_url,
                 )
 
 
@@ -403,7 +404,7 @@ class CreateImageOperator(BaseOperator):
         self.image_base_name = image_base_name
 
     def execute(self, context):
-        self.log.info(f"Creating image {self.image_base_name} on Puhti")
+        self.log.info("Creating image %s on Puhti", self.image_base_name)
         image_dir_path = os.path.join(self.base_path, self.image_base_name)
 
         ssh_hook = SSHHook(ssh_conn_id=self.ssh_conn_id)

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -1,4 +1,5 @@
 import os
+from requests.exceptions import RequestException
 
 from airflow.models import BaseOperator
 from airflow.hooks.base import BaseHook
@@ -10,8 +11,6 @@ from harvester.mets import METS, METSFileEmptyError
 from harvester.file import ALTOFile
 from harvester.pmh_interface import PMH_API
 from harvester import utils
-
-from requests.exceptions import RequestException
 
 
 class CreateConnectionOperator(BaseOperator):

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -2,14 +2,12 @@ import os
 from requests.exceptions import RequestException
 
 from airflow.models import BaseOperator
-from airflow.hooks.base import BaseHook
 from airflow.providers.ssh.hooks.ssh import SSHHook
 from airflow.models import Connection
 from airflow import settings
 
 from harvester.mets import METS, METSFileEmptyError
 from harvester.file import ALTOFile
-from harvester.pmh_interface import PMH_API
 from harvester import utils
 
 

--- a/tests/harvester/test_file.py
+++ b/tests/harvester/test_file.py
@@ -103,20 +103,18 @@ def test_download_to_remote(alto_file, sftp_client, sftp_server, mock_alto_downl
     """
 
     sftp = sftp_client.open_sftp()
-    output_path = str(
-        Path(sftp_server.root) / "some" / "sub" / "path" / "test_alto.xml"
-    )
+    output_path = Path(sftp_server.root) / "some" / "sub" / "path" / "test_alto.xml"
 
     utils.make_intermediate_dirs(
         sftp_client=sftp,
-        remote_directory=output_path.rsplit("/", maxsplit=1)[0],
+        remote_directory=output_path.parent,
     )
 
-    with sftp.file(output_path, "wb") as file:
+    with sftp.file(str(output_path), "wb") as file:
         alto_file.download(
             output_file=file,
             chunk_size=1024 * 1024,
         )
 
-    with sftp.file(output_path, "r") as file:
+    with sftp.file(str(output_path), "r") as file:
         assert file.read().decode("utf-8") == mock_alto_download

--- a/tests/harvester/test_pmh_interface.py
+++ b/tests/harvester/test_pmh_interface.py
@@ -41,19 +41,17 @@ def test_fetch_mets_with_custom_path(
     Ensure that a valid METS file is fetched and written to disk without filename.
     """
     api = PMH_API(oai_pmh_api_url)
-    output_file = str(
-        utils.mets_download_location(
-            dc_identifier=mets_dc_identifier,
-            base_path=tmp_path,
-            file_dir="mets",
-            filename="test.xml",
-        )
+    output_file = utils.mets_download_location(
+        dc_identifier=mets_dc_identifier,
+        base_path=tmp_path,
+        file_dir="mets",
+        filename="test.xml",
     )
     mocker.patch("builtins.open")
     with open(output_file, "wb") as mets_file:
         response = api.download_mets(mets_dc_identifier, mets_file)
 
-    builtins.open.assert_called_once_with(str(tmp_path / f"mets/test.xml"), "wb")
+    builtins.open.assert_called_once_with(tmp_path / "mets" / "test.xml", "wb")
     assert response.decode("utf-8") == expected_mets_response
 
 
@@ -65,13 +63,13 @@ def test_fetch_mets_with_default_path(
     """
     api = PMH_API(oai_pmh_api_url)
     binding_id = utils.binding_id_from_dc(mets_dc_identifier)
-    output_file = str(utils.mets_download_location(dc_identifier=mets_dc_identifier))
+    output_file = utils.mets_download_location(dc_identifier=mets_dc_identifier)
     mocker.patch("builtins.open")
     with open(output_file, "wb") as mets_file:
         response = api.download_mets(mets_dc_identifier, mets_file)
 
     builtins.open.assert_called_once_with(
-        str(cwd_in_tmp / f"downloads/{binding_id}/mets" / f"{binding_id}_METS.xml"),
+        cwd_in_tmp / "downloads" / binding_id / "mets" / f"{binding_id}_METS.xml",
         "wb",
     )
     assert response.decode("utf-8") == expected_mets_response

--- a/tests/harvester/test_utils.py
+++ b/tests/harvester/test_utils.py
@@ -23,8 +23,13 @@ def test_make_intermediate_dirs(sftp_server, sftp_client):
     """
     sftp = sftp_client.open_sftp()
     root_path = Path(sftp_server.root)
-    utils.make_intermediate_dirs(sftp, f"{root_path}/does/not/exist")
-    assert sftp.listdir(f"{root_path}/does/not") == ["exist"]
+    new_path = root_path / "does" / "not" / "exist"
+    utils.make_intermediate_dirs(sftp, new_path)
+
+    try:
+        sftp.chdir(str(new_path))
+    except IOError:
+        assert False, "Path {new_path} was not created"
 
 
 def test_calculate_batch_size():
@@ -70,7 +75,7 @@ def test_assign_bindings_to_images():
     Test that bindings are assigned to disk images correctly,
     the correct number of disk images are created.
     """
-    with open(f"tests/data/test_col_bindings", "r") as f:
+    with open("tests/data/test_col_bindings", "r") as f:
         bindings = f.read().splitlines()
 
     images_1 = utils.assign_bindings_to_images(bindings, 1000)
@@ -135,7 +140,7 @@ def test_read_bindings(tmpdir):
     with open("tests/data/binding_list.txt", "r") as f1:
         bindings = f1.read().splitlines()
         os.mkdir(Path(tmpdir) / "col-000")
-        with open(Path(tmpdir) / f"col-000/binding_ids_{date.today()}", "w") as f2:
+        with open(Path(tmpdir) / "col-000" / f"binding_ids_{date.today()}", "w") as f2:
             for binding in bindings:
                 f2.write(binding + "\n")
 

--- a/tests/pipeline/test_custom_operators.py
+++ b/tests/pipeline/test_custom_operators.py
@@ -39,8 +39,8 @@ def test_existing_mets_not_downloaded_again(
     Test that existing METS files are not redownloaded.
     """
     api = PMH_API(oai_pmh_api_url)
-    output_path = Path(sftp_server.root) / "dir"
-    mets_dir = output_path / "sub_dir" / "mets"
+    output_path = Path(sftp_server.root) / "sub_dir" / "binding_dir"
+    mets_dir = output_path / "mets"
     temp_path = Path(sftp_server.root) / "tmp"
 
     with ssh_server.client("user") as ssh_client:
@@ -62,7 +62,7 @@ def test_existing_mets_not_downloaded_again(
             tmpdir=temp_path,
             dc_identifier=mets_dc_identifier,
             binding_path=output_path,
-            file_dir="file_dir",
+            file_dir="mets",
         )
 
         sftp_mets_operator.execute(context={})
@@ -70,6 +70,11 @@ def test_existing_mets_not_downloaded_again(
         # Ensure that the METS file was not overwritten:
         with sftp.file(str(mets_dir / "379973_METS.xml"), "r") as sftp_file:
             assert sftp_file.read().decode("utf-8") == "test"
+
+        # Check that the METS file was not downloaded to another location within
+        # output_path either
+        files_in_output_path = sum(len(files) for _, _, files in os.walk(output_path))
+        assert files_in_output_path == 1
 
 
 def test_save_mets_sftp_operator(

--- a/tests/pipeline/test_custom_operators.py
+++ b/tests/pipeline/test_custom_operators.py
@@ -6,6 +6,7 @@ from airflow import settings
 from harvester import utils
 from harvester.mets import METSFileEmptyError
 from pipeline.plugins.operators.custom_operators import *
+from harvester.pmh_interface import PMH_API
 
 
 def test_create_connection_operator():


### PR DESCRIPTION
Before making functional changes for https://github.com/CSCfi/kielipankki-nlf-harvester/pull/29, I wanted to do some refactoring. 

Most prominently I unified representing paths. Previously some paths were strings and some Paths, which added cognitive load to working with the code. Now using Paths everywhere (except when a string is explicitly needed, and then converting as late as possible) to unify the practice. Alternatively the types could have been specified in the docstrings, but that felt like more work and as it would have required following call chains pretty far at some cases, it would also likely have been more error-prone. Thus unifying to Paths was chosen.

Unused local download operators were removed.

I also opted to follow some pylint recommendations that have real effects on performance/reliablity/etc and eliminated some false warnings that don't apply to our code.