### PR TITLE
KP-7389 post-refactoring

### DIFF
--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -178,19 +178,19 @@ def assign_update_bindings_to_images(bindings, image_split_file):
     return image_split
 
 
-def read_bindings(binding_base_path, set_id):
+def read_bindings(binding_list_dir, set_id):
     """
     Read and return a list of bindings from the latest binding ID file.
     """
     try:
         binding_id_files = [
             datetime.strptime(fname.split("_")[-1], "%Y-%m-%d").date()
-            for fname in os.listdir(binding_base_path / set_id)
+            for fname in os.listdir(binding_list_dir / set_id)
         ]
     except FileNotFoundError:
         raise FileNotFoundError(f"No binding ID file found for set {set_id}")
     latest = max(binding_id_files)
-    with open(binding_base_path / set_id / f"binding_ids_{str(latest)}", "r") as f:
+    with open(binding_list_dir / set_id / f"binding_ids_{str(latest)}", "r") as f:
         bindings = f.read().splitlines()
     return bindings
 

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -4,7 +4,6 @@ General utility functions for working with the OAI-PMH API, metadata and files.
 
 import os
 import json
-import re
 from pathlib import Path
 from datetime import datetime
 

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -189,3 +189,23 @@ def save_image_split(image_split, image_split_dir, set_id):
     with open(image_split_dir / f"{set_id}_images.json", "w") as json_file:
         image_split = {k: [] for k in image_split}
         json.dump(image_split, json_file)
+
+
+def remote_file_exists(sftp_client, path):
+    """
+    Check if a non-empty file already exists in the given remote path.
+
+    :param sftp_client: Client for accessing the remote machine via SFTP
+    :type sftp_client: :class:`paramiko.sftp_client.SFTPClient`
+    :param path: Path whose existence is to be checked
+    :type path: :class:`pathlib.Path`
+    :return: True if a non-empty file exists, otherwise False
+    """
+    try:
+        file_size = sftp_client.stat(str(path)).st_size
+    except OSError:
+        return False
+    else:
+        if file_size > 0:
+            return True
+    return False

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -61,26 +61,13 @@ def file_download_location(file, base_path=None, file_dir=None, filename=None):
     return Path(base_path) / Path(file_dir) / Path(filename)
 
 
-def mets_download_location(dc_identifier, base_path=None, file_dir=None, filename=None):
+def mets_file_name(dc_identifier):
     """
-    The output location can be specified with the components ``base_path``,
-    ``file_dir`` and ``filename``. If not given, the output location is as
-    follows:
+    Return file name for the METS file corresponding to given DC identifier.
 
-     ./downloads/[binding ID]/[type directory]/[binding ID]_METS.xml
-     ^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      base_path          file_dir                         filename
-
-    Return :class:`pathlib.Path`
+    The resulting file names are in [binding_id]_METS.xml format, e.g. 123456_METS.xml.
     """
-    if not base_path:
-        base_path = Path(os.getcwd()) / "downloads"
-    if not file_dir:
-        file_dir = Path(binding_id_from_dc(dc_identifier)) / "mets"
-    if not filename:
-        filename = f"{binding_id_from_dc(dc_identifier)}_METS.xml"
-
-    return Path(base_path) / Path(file_dir) / Path(filename)
+    return f"{binding_id_from_dc(dc_identifier)}_METS.xml"
 
 
 def binding_download_location(binding_id, depth=None):

--- a/pipeline/dags/download_images.py
+++ b/pipeline/dags/download_images.py
@@ -19,10 +19,10 @@ from harvester.pmh_interface import PMH_API
 
 INITIAL_DOWNLOAD = True
 
-BASE_PATH = Path("/scratch/project_2006633/nlf-harvester/images")
-TMPDIR = Path("/local_scratch/robot_2006633_puhti/harvester")
+OUTPUT_DIR = Path("/scratch/project_2006633/nlf-harvester/images")
+TMPDIR_ROOT = Path("/local_scratch/robot_2006633_puhti/harvester")
 IMAGE_SPLIT_DIR = Path("/home/ubuntu/image_split/")
-BINDING_BASE_PATH = Path("/home/ubuntu/binding_ids_all")
+BINDING_LIST_DIR = Path("/home/ubuntu/binding_ids_all")
 SSH_CONN_ID = "puhti_conn"
 HTTP_CONN_ID = "nlf_http_conn"
 COLLECTIONS = [
@@ -61,7 +61,7 @@ for col in COLLECTIONS:
 
         check_if_download_should_begin(
             set_id=col["id"],
-            binding_base_path=BINDING_BASE_PATH,
+            binding_list_dir=BINDING_LIST_DIR,
             http_conn_id=HTTP_CONN_ID,
         ) >> [
             begin_download,
@@ -77,11 +77,11 @@ for col in COLLECTIONS:
                 ssh_conn_id=SSH_CONN_ID,
                 initial_download=INITIAL_DOWNLOAD,
                 image_split_dir=IMAGE_SPLIT_DIR,
-                binding_base_path=BINDING_BASE_PATH,
-                base_path=BASE_PATH,
-                tmpdir=TMPDIR,
+                binding_list_dir=BINDING_LIST_DIR,
+                output_dir=OUTPUT_DIR,
+                tmpdir_root=TMPDIR_ROOT,
             )
-            >> clear_temporary_directory(SSH_CONN_ID, TMPDIR)
+            >> clear_temporary_directory(SSH_CONN_ID, TMPDIR_ROOT)
         )
 
     download_dag()

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -115,8 +115,7 @@ def download_set(
                         task_id="download_binding_batch",
                         trigger_rule="none_skipped",
                         ssh_conn_id=ssh_conn_id,
-                        image_base_name=image_base_name,
-                        tmpdir_root=tmpdir_root,
+                        image_directory=tmpdir_root / image_base_name,
                         api=api,
                     ).expand(
                         batch=utils.split_into_download_batches(image_split[image])

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -90,21 +90,23 @@ def download_set(
                 else:
                     image_base_name = set_id
 
+                file_download_dir = tmpdir_root / image_base_name
+                image_path = output_dir / (image_base_name + ".sqfs")
+
                 prepare_download_location = PrepareDownloadLocationOperator(
                     task_id=f"prepare_download_location_{image_base_name}",
                     trigger_rule="none_skipped",
                     ssh_conn_id=ssh_conn_id,
-                    file_download_dir=tmpdir_root / image_base_name,
-                    old_image_path=output_dir / (image_base_name + ".sqfs"),
+                    file_download_dir=file_download_dir,
+                    old_image_path=image_path,
                 )
 
                 create_image = CreateImageOperator(
                     task_id=f"create_image_{image_base_name}",
                     trigger_rule="none_skipped",
                     ssh_conn_id=ssh_conn_id,
-                    tmp_path=tmpdir_root,
-                    output_dir=output_dir,
-                    image_base_name=image_base_name,
+                    data_source=file_download_dir,
+                    image_path=image_path,
                 )
 
                 (

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -94,9 +94,8 @@ def download_set(
                     task_id=f"prepare_download_location_{image_base_name}",
                     trigger_rule="none_skipped",
                     ssh_conn_id=ssh_conn_id,
-                    tmp_path=tmpdir_root,
-                    output_dir=output_dir,
-                    image_base_name=image_base_name,
+                    file_download_dir=tmpdir_root / image_base_name,
+                    old_image_path=output_dir / (image_base_name + ".sqfs"),
                 )
 
                 create_image = CreateImageOperator(

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -341,13 +341,12 @@ class PrepareDownloadLocationOperator(BaseOperator):
         with ssh_hook.get_conn() as ssh_client:
             sftp_client = ssh_client.open_sftp()
 
+            self.create_image_folder(sftp_client, self.file_download_dir)
+
             if file_exists(sftp_client, self.old_image_path):
                 self.extract_image(
                     ssh_client,
                 )
-
-            else:
-                self.create_image_folder(sftp_client, self.file_download_dir)
 
 
 class CreateImageOperator(BaseOperator):

--- a/tests/harvester/test_pmh_interface.py
+++ b/tests/harvester/test_pmh_interface.py
@@ -34,44 +34,17 @@ def test_binding_ids_from_two_page_response(oai_pmh_api_url, two_page_pmh_respon
     _check_result(ids, two_page_pmh_response)
 
 
-def test_fetch_mets_with_custom_path(
-    oai_pmh_api_url, mets_dc_identifier, expected_mets_response, tmp_path, mocker
+def test_fetch_mets(
+    oai_pmh_api_url, mets_dc_identifier, expected_mets_response, tmp_path
 ):
     """
-    Ensure that a valid METS file is fetched and written to disk without filename.
+    Ensure that a valid METS file is fetched and written to disk.
     """
     api = PMH_API(oai_pmh_api_url)
-    output_file = utils.mets_download_location(
-        dc_identifier=mets_dc_identifier,
-        base_path=tmp_path,
-        file_dir="mets",
-        filename="test.xml",
-    )
-    mocker.patch("builtins.open")
+    output_file = tmp_path / "test_mets.xml"
     with open(output_file, "wb") as mets_file:
         response = api.download_mets(mets_dc_identifier, mets_file)
 
-    builtins.open.assert_called_once_with(tmp_path / "mets" / "test.xml", "wb")
-    assert response.decode("utf-8") == expected_mets_response
-
-
-def test_fetch_mets_with_default_path(
-    oai_pmh_api_url, mets_dc_identifier, expected_mets_response, mocker, cwd_in_tmp
-):
-    """
-    Ensure that a valid METS file is fetched and written to disk with default path.
-    """
-    api = PMH_API(oai_pmh_api_url)
-    binding_id = utils.binding_id_from_dc(mets_dc_identifier)
-    output_file = utils.mets_download_location(dc_identifier=mets_dc_identifier)
-    mocker.patch("builtins.open")
-    with open(output_file, "wb") as mets_file:
-        response = api.download_mets(mets_dc_identifier, mets_file)
-
-    builtins.open.assert_called_once_with(
-        cwd_in_tmp / "downloads" / binding_id / "mets" / f"{binding_id}_METS.xml",
-        "wb",
-    )
     assert response.decode("utf-8") == expected_mets_response
 
 

--- a/tests/pipeline/test_custom_operators.py
+++ b/tests/pipeline/test_custom_operators.py
@@ -46,8 +46,7 @@ def test_existing_mets_not_downloaded_again(
     Test that existing METS files are not redownloaded.
     """
     api = PMH_API(oai_pmh_api_url)
-    tmp_path = Path(sftp_server.root) / "tmp"
-    mets_dir = tmp_path / "mets"
+    mets_dir = Path(sftp_server.root) / "tmp" / "mets"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
@@ -65,9 +64,8 @@ def test_existing_mets_not_downloaded_again(
             api=api,
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir_root=tmp_path,
             dc_identifier=mets_dc_identifier,
-            file_dir="mets",
+            output_directory=mets_dir,
         )
 
         sftp_mets_operator.execute(context={})
@@ -78,7 +76,7 @@ def test_existing_mets_not_downloaded_again(
 
         # Check that the METS file was not downloaded to another location within
         # output_path either
-        files_in_output_path = sum(len(files) for _, _, files in os.walk(tmp_path))
+        files_in_output_path = sum(len(files) for _, _, files in os.walk(mets_dir))
         assert files_in_output_path == 1
 
 
@@ -96,8 +94,7 @@ def test_existing_tmp_file_does_not_prevent_download(
     executing it, and checking that the proper file has been created afterwards.
     """
     api = PMH_API(oai_pmh_api_url)
-    tmp_path = Path(sftp_server.root) / "tmp"
-    mets_dir = tmp_path / "mets"
+    mets_dir = Path(sftp_server.root) / "tmp" / "mets"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
@@ -112,9 +109,8 @@ def test_existing_tmp_file_does_not_prevent_download(
             api=api,
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir_root=tmp_path,
             dc_identifier=mets_dc_identifier,
-            file_dir="mets",
+            output_directory=mets_dir,
         )
 
         tmpfile_path = sftp_mets_operator.tmp_path(sftp_mets_operator.output_file)
@@ -139,7 +135,7 @@ def test_save_mets_sftp_operator(
     """
 
     api = PMH_API(oai_pmh_api_url)
-    tmp_path = Path(sftp_server.root) / "tmp" / "sub" / "path"
+    mets_dir = Path(sftp_server.root) / "tmp" / "sub" / "path"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
@@ -149,14 +145,13 @@ def test_save_mets_sftp_operator(
             api=api,
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir_root=tmp_path,
             dc_identifier=mets_dc_identifier,
-            file_dir="file_dir",
+            output_directory=mets_dir,
         )
 
         sftp_mets_operator.execute(context={})
 
-        with sftp.file(str(tmp_path / "file_dir" / "379973_METS.xml"), "r") as file:
+        with sftp.file(str(mets_dir / "379973_METS.xml"), "r") as file:
             assert file.read().decode("utf-8") == expected_mets_response
 
 
@@ -172,7 +167,7 @@ def test_empty_mets(
     """
 
     api = PMH_API(oai_pmh_api_url)
-    tmp_path = Path(sftp_server.root) / "tmp" / "sub" / "path"
+    mets_dir = Path(sftp_server.root) / "tmp" / "sub" / "path"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
@@ -182,9 +177,8 @@ def test_empty_mets(
             api=api,
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir_root=tmp_path,
             dc_identifier=empty_mets_dc_identifier,
-            file_dir="file_dir",
+            output_directory=mets_dir,
         )
 
         with pytest.raises(METSFileEmptyError):
@@ -203,7 +197,7 @@ def test_failed_mets_request(
     """
 
     api = PMH_API(oai_pmh_api_url)
-    tmp_path = Path(sftp_server.root) / "tmp" / "sub" / "path"
+    mets_dir = Path(sftp_server.root) / "tmp" / "sub" / "path"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
@@ -213,9 +207,8 @@ def test_failed_mets_request(
             api=api,
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir_root=tmp_path,
             dc_identifier=failed_mets_dc_identifier,
-            file_dir="file_dir",
+            output_directory=mets_dir,
         )
 
         with pytest.raises(RequestException):
@@ -254,10 +247,9 @@ def test_save_altos_sftp_operator(
             task_id="test_save_altos_remote",
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir_root=tmp_path,
-            file_dir=alto_dir,
-            mets_path=mets_dir,
+            mets_directory=mets_dir,
             dc_identifier=mets_dc_identifier,
+            output_directory=alto_dir,
         )
 
         operator.execute(context={})
@@ -285,7 +277,6 @@ def test_existing_altos_not_downloaded_again(
     mets_dir = output_path / "sub_dir" / "mets"
     alto_dir = output_path / "sub_dir" / "alto"
     mets_file = mets_dir / "379973_METS.xml"
-    tmp_path = Path(sftp_server.root) / "tmp"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
@@ -317,10 +308,9 @@ def test_existing_altos_not_downloaded_again(
             task_id="test_save_altos_remote",
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir_root=tmp_path,
-            file_dir=alto_dir,
-            mets_path=mets_dir,
+            mets_directory=mets_dir,
             dc_identifier=mets_dc_identifier,
+            output_directory=alto_dir,
         )
 
         operator.execute(context={})

--- a/tests/pipeline/test_custom_operators.py
+++ b/tests/pipeline/test_custom_operators.py
@@ -227,16 +227,15 @@ def test_save_altos_sftp_operator(
     to a remote server.
     """
     tmp_path = Path(sftp_server.root) / "tmp"
-    mets_dir = tmp_path / "sub_dir" / "mets"
     alto_dir = tmp_path / "sub_dir" / "alto"
-    mets_file = mets_dir / "379973_METS.xml"
+    mets_file = tmp_path / "mets_dir" / "379973_METS.xml"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
 
         utils.make_intermediate_dirs(
             sftp_client=sftp,
-            remote_directory=mets_dir,
+            remote_directory=mets_file.parent,
         )
 
         with sftp.file(str(mets_file), "w") as sftp_file:
@@ -247,7 +246,7 @@ def test_save_altos_sftp_operator(
             task_id="test_save_altos_remote",
             sftp_client=sftp,
             ssh_client=ssh_client,
-            mets_directory=mets_dir,
+            mets_path=mets_file,
             dc_identifier=mets_dc_identifier,
             output_directory=alto_dir,
         )
@@ -274,16 +273,15 @@ def test_existing_altos_not_downloaded_again(
     Test that existing ALTO files are not redownloaded.
     """
     output_path = Path(sftp_server.root) / "dir"
-    mets_dir = output_path / "sub_dir" / "mets"
     alto_dir = output_path / "sub_dir" / "alto"
-    mets_file = mets_dir / "379973_METS.xml"
+    mets_file = output_path / "mets_dir" / "379973_METS.xml"
 
     with ssh_server.client("user") as ssh_client:
         sftp = ssh_client.open_sftp()
 
         utils.make_intermediate_dirs(
             sftp_client=sftp,
-            remote_directory=mets_dir,
+            remote_directory=mets_file.parent,
         )
 
         with sftp.file(str(mets_file), "w") as sftp_file:
@@ -308,7 +306,7 @@ def test_existing_altos_not_downloaded_again(
             task_id="test_save_altos_remote",
             sftp_client=sftp,
             ssh_client=ssh_client,
-            mets_directory=mets_dir,
+            mets_path=mets_file,
             dc_identifier=mets_dc_identifier,
             output_directory=alto_dir,
         )

--- a/tests/pipeline/test_custom_operators.py
+++ b/tests/pipeline/test_custom_operators.py
@@ -65,7 +65,7 @@ def test_existing_mets_not_downloaded_again(
             api=api,
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir=tmp_path,
+            tmpdir_root=tmp_path,
             dc_identifier=mets_dc_identifier,
             file_dir="mets",
         )
@@ -112,7 +112,7 @@ def test_existing_tmp_file_does_not_prevent_download(
             api=api,
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir=tmp_path,
+            tmpdir_root=tmp_path,
             dc_identifier=mets_dc_identifier,
             file_dir="mets",
         )
@@ -149,7 +149,7 @@ def test_save_mets_sftp_operator(
             api=api,
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir=tmp_path,
+            tmpdir_root=tmp_path,
             dc_identifier=mets_dc_identifier,
             file_dir="file_dir",
         )
@@ -182,7 +182,7 @@ def test_empty_mets(
             api=api,
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir=tmp_path,
+            tmpdir_root=tmp_path,
             dc_identifier=empty_mets_dc_identifier,
             file_dir="file_dir",
         )
@@ -213,7 +213,7 @@ def test_failed_mets_request(
             api=api,
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir=tmp_path,
+            tmpdir_root=tmp_path,
             dc_identifier=failed_mets_dc_identifier,
             file_dir="file_dir",
         )
@@ -254,7 +254,7 @@ def test_save_altos_sftp_operator(
             task_id="test_save_altos_remote",
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir=tmp_path,
+            tmpdir_root=tmp_path,
             file_dir=alto_dir,
             mets_path=mets_dir,
             dc_identifier=mets_dc_identifier,
@@ -317,7 +317,7 @@ def test_existing_altos_not_downloaded_again(
             task_id="test_save_altos_remote",
             sftp_client=sftp,
             ssh_client=ssh_client,
-            tmpdir=tmp_path,
+            tmpdir_root=tmp_path,
             file_dir=alto_dir,
             mets_path=mets_dir,
             dc_identifier=mets_dc_identifier,


### PR DESCRIPTION
This PR does not alter the functionality of the DAG. Instead, it contains refactoring, mostly concentrated around how paths to various files and directories are handled along the chain of tasks and operators.

First of all, the global configuration variables and their corresponding taks/operator arguments were renamed to be more descriptive. Now it is hopefully more clear what each of them means and the same term means the same thing everywhere.

Then, path construction was moved to higher level from the actual download operators. This brings us closer to having one authoritative source for information as opposed to e.g. METS and ALTO downloading operators constructing the same METS path individually, which is prone to cause trouble if we change the logic.