### PR TITLE
KP-7397 Limit mksquashfs memory usage to 2GB

### DIFF
--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -376,9 +376,10 @@ class CreateImageOperator(BaseOperator):
 
         exit_code = stdout.channel.recv_exit_status()
         if exit_code != 0:
+            error_message = "\n".join(stderr.readlines())
             raise ImageCreationError(
                 f"Command {command} failed (exit code {exit_code}). Stderr output:\n"
-                f"{stderr}"
+                f"{error_message}"
             )
 
     def temporary_files_present(self, sftp_client, directory):

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -415,7 +415,7 @@ class CreateImageOperator(BaseOperator):
                 self.log.info("Creating temporary image in %s on Puhti", tmp_image_path)
                 self.ssh_execute_and_raise(
                     ssh_client,
-                    f"mksquashfs {self.data_source} {tmp_image_path}",
+                    f"mksquashfs {self.data_source} {tmp_image_path} -mem 2G",
                 )
 
                 self.log.info(


### PR DESCRIPTION
By default mksquashfs uses many cores and a lot of memory. This can cause the program to get killed due to running out of memory on Puhti login node. Excessive memory usage on login node is also rude.

2GB seems to be enough for the squashfs creation jobs to still go through nicely.

As an added bonus, fixed error messages not really being printed if an error occurs during command execution over SSH.