### PR TITLE
KP-7398 Use SSH key with Puhti connection

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -20,7 +20,17 @@ airflow_firstname: "Kielipankki"
 airflow_lastname: "User"
 airflow_email: "ling-admin@listat.csc.fi"
 
+puhti_robot_user: "robot_2006633_puhti"
 puhti_robot_password: "{{ lookup('passwordstore', 'lb_passwords/airflow/robot_2006633_puhti') }}"
+puhti_robot_ssh_key_path: "/home/{{ ansible_user }}/.ssh/id_ed25519_robot_2006633_puhti"
+
+puhti_conn_conf:
+  conn_type: "ssh"
+  host: "puhti-login12.csc.fi"
+  login: "{{ puhti_robot_user }}"
+  password: "{{ lookup('passwordstore', 'lb_passwords/airflow/private-key-password-robot_2006633_puhti') }}"
+  extra:
+    key_file: "{{ puhti_robot_ssh_key_path }}"
 
 authorized_users:
   - ktegel

--- a/ansible/harvesterPouta.yml
+++ b/ansible/harvesterPouta.yml
@@ -25,6 +25,11 @@
           - "193.166.84.0/24" #CSC VPN
           - "193.166.85.0/24" #CSC VPN
 
+- name: Setup Puhti access for Airflow
+  hosts: puhti
+  roles:
+    - public-key-to-puhti
+
 - name: Install requirements for Airflow
   hosts: airflow
   roles:

--- a/ansible/inventories/dev
+++ b/ansible/inventories/dev
@@ -10,3 +10,7 @@ all:
         86.50.229.214:
           ansible_user: ubuntu
           navbar_color: "#ff5800"
+    puhti:
+      hosts:
+        puhti.csc.fi:
+          ansible_user: "{{ puhti_robot_user }}"

--- a/ansible/inventories/prod
+++ b/ansible/inventories/prod
@@ -10,3 +10,7 @@ all:
       hosts:
         86.50.229.130
            ansible_user: ubuntu
+    puhti:
+      hosts:
+        puhti.csc.fi:
+          ansible_user: "{{ puhti_robot_user }}"

--- a/ansible/roles/harvester-setup/tasks/main.yml
+++ b/ansible/roles/harvester-setup/tasks/main.yml
@@ -60,6 +60,12 @@
     - never
     - dag-update
 
+- name: Add private key for connecting to Puhti
+  ansible.builtin.copy:
+    dest: "{{ puhti_robot_ssh_key_path }}"
+    mode: "0600"
+    content: "{{ lookup('passwordstore', 'lb_passwords/airflow/private-key-robot_2006633_puhti') | replace('\\n', '\n') }}"
+
 # The or-operator ("||") means that the latter part of the command (new
 # connection creation) is only executed if the former (grepping for puhti_conn
 # in pre-existing connections) fails (i.e. puhti_conn not found).
@@ -68,10 +74,7 @@
     airflow connections list | grep 'puhti_conn'
     ||
     airflow connections add 'puhti_conn'
-    --conn-type 'ssh'
-    --conn-host 'puhti-login12.csc.fi'
-    --conn-login 'robot_2006633_puhti'
-    --conn-password {{ puhti_robot_password }}
+    --conn-json '{{ puhti_conn_conf | to_json }}'
 
 - name: Create HTTP connection to NLF if not already present
   ansible.builtin.shell: >

--- a/ansible/roles/public-key-to-puhti/tasks/main.yml
+++ b/ansible/roles/public-key-to-puhti/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Add public SSH key to puhti for the robot account
+  ansible.posix.authorized_key:
+    user: "{{ puhti_robot_user }}"
+    key: "{{ lookup('passwordstore', 'lb_passwords/airflow/public-key-robot_2006633_puhti') }}"


### PR DESCRIPTION
Replaced old password-based authentication with SSH key use. This was suggested to be more robust against the account/IP combination getting banned from Puhti.

It was somewhat difficult to make the connection configuration both functional and somewhat readable, but the current solution of defining the configuration as a yaml dict and parsing that to json at runtime seems like a reasonable compromise. That way we don't need to try to juggle the nested single and double quotation marks and escaping or not escaping them based on their role, nor do we need to worry about avoiding newlines inside the parameter strings.

Note that unlike [SSH Connection
docs](https://airflow.apache.org/docs/apache-airflow-providers-ssh/stable/connections/ssh.html) imply, the `private_key_passphrase` extra parameter does not seem to work. Instead the same `password` parameter that is used for password authentication is used with the SSH key too.

When testing the connection, one should note that the test-button in the Airflow GUI does not work with password-protected SSH keys. Command line testing (e.g. `airflow connections test puhti_conn`) works as expected though.