### PR TITLE
KP-7399 Reduce the max number of bindings in an image

### DIFF
--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -97,9 +97,9 @@ def calculate_batch_size(col_size):
     if col_size < 50000:
         return 100
     if col_size < 500000:
-        return 500
+        return 1500
     else:
-        return 2000
+        return 3000
 
 
 def split_into_download_batches(bindings):

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -93,9 +93,9 @@ def calculate_batch_size(col_size):
     Return a suitable download batch size for a collection.
     """
     if col_size < 500:
-        return min(col_size, 10)
+        return min(col_size, 100)
     if col_size < 50000:
-        return 100
+        return 1000
     if col_size < 500000:
         return 1500
     else:

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -187,7 +187,7 @@ def save_image_split(image_split, image_split_dir, set_id):
     if not os.path.exists(image_split_dir):
         os.makedirs(image_split_dir)
     with open(image_split_dir / f"{set_id}_images.json", "w") as json_file:
-        image_split = {k: [] for k in image_split}
+        # image_split = {k: [] for k in image_split}
         json.dump(image_split, json_file)
 
 

--- a/pipeline/dags/download_images.py
+++ b/pipeline/dags/download_images.py
@@ -28,8 +28,8 @@ HTTP_CONN_ID = "nlf_http_conn"
 COLLECTIONS = [
     {"id": "col-361", "image_size": 150},
     {"id": "col-501", "image_size": 5000},
-    {"id": "col-82", "image_size": 150000},
-    {"id": "col-24", "image_size": 100000},
+    {"id": "col-82", "image_size": 70000},
+    {"id": "col-24", "image_size": 70000},
 ]
 
 default_args = {

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -305,7 +305,7 @@ class PrepareDownloadLocationOperator(BaseOperator):
 
     def extract_image(self, ssh_client):
         """
-        Extract contents of a disk image in given path.
+        Extract contents of a disk image to the download directory.
 
         Potentially pre-existing content is overwritten, but there
         should be none as the directory should have been just created

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -306,9 +306,13 @@ class PrepareDownloadLocationOperator(BaseOperator):
     def extract_image(self, ssh_client):
         """
         Extract contents of a disk image in given path.
+
+        Potentially pre-existing content is overwritten, but there
+        should be none as the directory should have been just created
+        for the new image.
         """
         ssh_client.exec_command(
-            f"unsquashfs -d {self.file_download_dir} {self.old_image_path}"
+            f"unsquashfs -f -d {self.file_download_dir} {self.old_image_path}"
         )
 
     def create_image_folder(self, sftp_client, image_dir_path):


### PR DESCRIPTION
The quota on local_scratch limits the size of the squashfs images we can create. The default quota of local_scratch on Puhti is 50 GB/user, ours has now been increased to 200 GB but this is still not sufficient for over 100 k bindings. In test download, collection 82 images 12 and 13 were cut at 200 GB, so they can provide a rough idea about the number of bindings/pages that fit into our quota. This was 87 138 bindings for image 12 and 75 127 bindings for image 13.

The difference in the number of bindings likely arises from differences in the number of pages in a binding. For image 12 the total number of pages was 360544 and for image 13 it was 370380, which are closer to each other.

As we don't currently have a way to split images according to the number of pages or the actual file size (as that would require downloading all METS files beforehand or getching more information from OAI-PMH than we currently do), the out of space problem was mitigated by lowering the biggest image sizes to 70 k bindings. This might still be too many for thicker bindings (current tests runs were on newspapers, magazines are likely to have more pages, and newer newspapers are thicker than old ones too) but we'll find that out when doing a bigger run.