### PR TITLE
KP-7389 Fix broken old image extraction

### DIFF
--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -305,7 +305,7 @@ class PrepareDownloadLocationOperator(BaseOperator):
 
     def extract_image(self, ssh_client):
         """
-        Extract contents of a disk image in given path.
+        Extract contents of a disk image to the download directory.
 
         Potentially pre-existing content is overwritten, but there
         should be none as the directory should have been just created

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -306,9 +306,13 @@ class PrepareDownloadLocationOperator(BaseOperator):
     def extract_image(self, ssh_client):
         """
         Extract contents of a disk image in given path.
+
+        Potentially pre-existing content is overwritten, but there
+        should be none as the directory should have been just created
+        for the new image.
         """
         ssh_client.exec_command(
-            f"unsquashfs -d {self.file_download_dir} {self.old_image_path}"
+            f"unsquashfs -f -d {self.file_download_dir} {self.old_image_path}"
         )
 
     def create_image_folder(self, sftp_client, image_dir_path):


### PR DESCRIPTION
If not used with `-f` option, `unsquashfs` refuses to write content if the destination directory exists, even if it is empty. Using the flag should be safe as we are writing to `local_scratch` where there should be no pre-existing data (and the empty directory has just been created). This could turn out to be problematic if we mix up the paths so that we end up overwriting something, but in that case we'll be in trouble anyway, then it's just about whether we'll be in trouble after unsquashfs'ing or after downloading the files from NLF.

The other option would be to reinstate the old logic where we don't create the directory at all if extracting an old image. This would eliminate the need for the scary --force at the cost of the code being maybe a bit less obvious for the reader.