### PR TITLE
KP-6678 Create restic snapshot to allas after each download

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -20,6 +20,8 @@ airflow_firstname: "Kielipankki"
 airflow_lastname: "User"
 airflow_email: "ling-admin@listat.csc.fi"
 
+restic_repository: "s3:https://a3s.fi/nlf-harvester-backup"
+
 puhti_robot_user: "robot_2006633_puhti"
 puhti_robot_password: "{{ lookup('passwordstore', 'lb_passwords/airflow/robot_2006633_puhti') }}"
 puhti_robot_ssh_key_path: "/home/{{ ansible_user }}/.ssh/id_ed25519_robot_2006633_puhti"

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -20,7 +20,7 @@ airflow_firstname: "Kielipankki"
 airflow_lastname: "User"
 airflow_email: "ling-admin@listat.csc.fi"
 
-restic_repository: "s3:https://a3s.fi/nlf-harvester-backup"
+restic_repository: "s3:https://a3s.fi/nlf-harvester-versioning"
 
 puhti_robot_user: "robot_2006633_puhti"
 puhti_robot_password: "{{ lookup('passwordstore', 'lb_passwords/airflow/robot_2006633_puhti') }}"

--- a/ansible/harvesterPouta.yml
+++ b/ansible/harvesterPouta.yml
@@ -25,10 +25,11 @@
           - "193.166.84.0/24" #CSC VPN
           - "193.166.85.0/24" #CSC VPN
 
-- name: Setup Puhti access for Airflow
+- name: Setup Puhti access for Airflow and make sure restic script exists
   hosts: puhti
   roles:
     - public-key-to-puhti
+    - restic-script-to-puhti
 
 - name: Install requirements for Airflow
   hosts: airflow

--- a/ansible/inventories/dev
+++ b/ansible/inventories/dev
@@ -14,3 +14,4 @@ all:
       hosts:
         puhti.csc.fi:
           ansible_user: "{{ puhti_robot_user }}"
+          ansible_password: "{{ puhti_robot_password }}"

--- a/ansible/roles/airflow-requirements/tasks/main.yml
+++ b/ansible/roles/airflow-requirements/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: Install Airflow
   ansible.builtin.pip:
     name: apache-airflow[async,postgres,google]
-    extra_args: --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-latest/constraints-3.10.txt"
+    extra_args: --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-3.10.txt"
   become: yes
 
 - name: Create gunicorn log directory

--- a/ansible/roles/harvester-setup/tasks/main.yml
+++ b/ansible/roles/harvester-setup/tasks/main.yml
@@ -60,6 +60,11 @@
     - never
     - dag-update
 
+- name: Create a file for restic environment variables
+  template:
+    src: restic_env.yaml.j2
+    dest: /home/ubuntu/restic_env.yaml
+
 - name: Add private key for connecting to Puhti
   ansible.builtin.copy:
     dest: "{{ puhti_robot_ssh_key_path }}"

--- a/ansible/roles/harvester-setup/templates/restic_env.yaml.j2
+++ b/ansible/roles/harvester-setup/templates/restic_env.yaml.j2
@@ -1,0 +1,4 @@
+AWS_SECRET_ACCESS_KEY: {{ lookup('passwordstore', 'lb_passwords/airflow/aws_secret_access_key') }}
+AWS_ACCESS_KEY_ID: {{ lookup('passwordstore', 'lb_passwords/airflow/aws_access_key_id') }}
+RESTIC_REPOSITORY: {{ restic_repository }}
+RESTIC_PASSWORD: {{ lookup('passwordstore', 'lb_passwords/airflow/restic_password') }}

--- a/ansible/roles/restic-script-to-puhti/files/create_snapshot.sh
+++ b/ansible/roles/restic-script-to-puhti/files/create_snapshot.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+module load allas
+restic backup $1

--- a/ansible/roles/restic-script-to-puhti/tasks/main.yml
+++ b/ansible/roles/restic-script-to-puhti/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: Make sure that restic script exists in Puhti
+  ansible.builtin.copy:
+    src: ../files/create_snapshot.sh
+    dest: /projappl/project_2006633/local/bin/create_snapshot.sh

--- a/pipeline/dags/download_images.py
+++ b/pipeline/dags/download_images.py
@@ -14,7 +14,7 @@ from includes.tasks import (
     check_if_download_should_begin,
     download_set,
     clear_temporary_directory,
-    create_restic_snapshot
+    create_restic_snapshot,
 )
 from harvester.pmh_interface import PMH_API
 
@@ -83,9 +83,11 @@ for col in COLLECTIONS:
                 pathdict=pathdict,
             )
             >> clear_temporary_directory(SSH_CONN_ID, pathdict["TMPDIR_ROOT"])
-            >> create_restic_snapshot(SSH_CONN_ID,
-                             pathdict["EXTRA_BIN_DIR"]/"create_snapshot.sh",
-                             pathdict["OUTPUT_DIR"]/"images")
+            >> create_restic_snapshot(
+                SSH_CONN_ID,
+                pathdict["EXTRA_BIN_DIR"] / "create_snapshot.sh",
+                pathdict["OUTPUT_DIR"] / "images",
+            )
         )
 
     download_dag()

--- a/pipeline/dags/download_images.py
+++ b/pipeline/dags/download_images.py
@@ -14,14 +14,15 @@ from includes.tasks import (
     check_if_download_should_begin,
     download_set,
     clear_temporary_directory,
+    restic_backup
 )
 from harvester.pmh_interface import PMH_API
 
 INITIAL_DOWNLOAD = True
 
 pathdict = {
-    "OUTPUT_DIR": Path("/scratch/project_2006633/nlf-harvester"),
-    "TMPDIR_ROOT": Path("/local_scratch/robot_2006633_puhti/harvester"),
+    "OUTPUT_DIR": Path("/scratch/project_2006633/restic-dev/"),
+    "TMPDIR_ROOT": Path("/local_scratch/robot_2006633_puhti/restic-dev"),
     "EXTRA_BIN_DIR": Path("/projappl/project_2006633/local/bin"),
     "IMAGE_SPLIT_DIR": Path("/home/ubuntu/image_split/"),
     "BINDING_LIST_DIR": Path("/home/ubuntu/binding_ids_all"),
@@ -82,6 +83,9 @@ for col in COLLECTIONS:
                 pathdict=pathdict,
             )
             >> clear_temporary_directory(SSH_CONN_ID, pathdict["TMPDIR_ROOT"])
+            >> restic_backup(SSH_CONN_ID,
+                             "/users/robot_2006633_puhti/create_snapshot.sh",
+                             pathdict["OUTPUT_DIR"]/"images")
         )
 
     download_dag()

--- a/pipeline/dags/download_images.py
+++ b/pipeline/dags/download_images.py
@@ -21,8 +21,8 @@ from harvester.pmh_interface import PMH_API
 INITIAL_DOWNLOAD = True
 
 pathdict = {
-    "OUTPUT_DIR": Path("/scratch/project_2006633/restic-dev/"),
-    "TMPDIR_ROOT": Path("/local_scratch/robot_2006633_puhti/restic-dev"),
+    "OUTPUT_DIR": Path("/scratch/project_2006633/nlf-harvester"),
+    "TMPDIR_ROOT": Path("/local_scratch/robot_2006633_puhti/harvester"),
     "EXTRA_BIN_DIR": Path("/projappl/project_2006633/local/bin"),
     "IMAGE_SPLIT_DIR": Path("/home/ubuntu/image_split/"),
     "BINDING_LIST_DIR": Path("/home/ubuntu/binding_ids_all"),

--- a/pipeline/dags/download_images.py
+++ b/pipeline/dags/download_images.py
@@ -14,7 +14,7 @@ from includes.tasks import (
     check_if_download_should_begin,
     download_set,
     clear_temporary_directory,
-    restic_backup
+    create_restic_snapshot
 )
 from harvester.pmh_interface import PMH_API
 
@@ -83,8 +83,8 @@ for col in COLLECTIONS:
                 pathdict=pathdict,
             )
             >> clear_temporary_directory(SSH_CONN_ID, pathdict["TMPDIR_ROOT"])
-            >> restic_backup(SSH_CONN_ID,
-                             "/users/robot_2006633_puhti/create_snapshot.sh",
+            >> create_restic_snapshot(SSH_CONN_ID,
+                             pathdict["EXTRA_BIN_DIR"]/"create_snapshot.sh",
                              pathdict["OUTPUT_DIR"]/"images")
         )
 

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -140,8 +140,8 @@ def clear_temporary_directory(ssh_conn_id, tmpdir_root):
         ssh_client.exec_command(f"rm -r {tmpdir_root}/*")
 
 
-@task(task_id="restic_backup", trigger_rule="all_done")
-def restic_backup(ssh_conn_id, script_path, output_dir):
+@task(task_id="create_restic_snapshot", trigger_rule="all_done")
+def create_restic_snapshot(ssh_conn_id, script_path, output_dir):
     ssh_hook = SSHHook(ssh_conn_id=ssh_conn_id)
     with ssh_hook.get_conn() as ssh_client:
         with open("/home/ubuntu/restic_env.yaml", "r") as fobj:

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -153,8 +153,14 @@ def restic_backup(ssh_conn_id, script_path, output_dir):
                                                     get_pty=True)
 
         output = "\n".join(stdout.readlines())
-        print("STDOUT:", output)
+        print(output)
 
         if stdout.channel.recv_exit_status() != 0:
             error_msg = "\n".join(stderr.readlines())
-            print(f"Creating snapshot failed with error:\n{error_msg}")
+            raise CreateSnapshotError(f"Creating snapshot failed with error:\n{error_msg}")
+
+
+class CreateSnapshotError(Exception):
+    """
+    Error raised when an error occurs during the creation of a restic snapshot
+    """

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -90,7 +90,9 @@ def download_set(
                     image_base_name = set_id
 
                 file_download_dir = pathdict["TMPDIR_ROOT"] / image_base_name
-                image_path = pathdict["OUTPUT_DIR"] / "images" / (image_base_name + ".sqfs")
+                image_path = (
+                    pathdict["OUTPUT_DIR"] / "images" / (image_base_name + ".sqfs")
+                )
                 tar_directory = pathdict["OUTPUT_DIR"] / "tar" / image_base_name
 
                 prepare_download_location = PrepareDownloadLocationOperator(
@@ -99,7 +101,7 @@ def download_set(
                     ssh_conn_id=ssh_conn_id,
                     file_download_dir=file_download_dir,
                     old_image_path=image_path,
-                    tar_dir = tar_directory,
+                    tar_dir=tar_directory,
                     extra_bin_dir=pathdict["EXTRA_BIN_DIR"],
                 )
 
@@ -118,11 +120,14 @@ def download_set(
                         task_id="download_binding_batch",
                         trigger_rule="none_skipped",
                         ssh_conn_id=ssh_conn_id,
-                        tmp_download_directory=pathdict["TMPDIR_ROOT"] / image_base_name,
+                        tmp_download_directory=pathdict["TMPDIR_ROOT"]
+                        / image_base_name,
                         tar_directory=tar_directory,
                         api=api,
                     ).expand(
-                        batch_with_index=utils.split_into_download_batches(image_split[image])
+                        batch_with_index=utils.split_into_download_batches(
+                            image_split[image]
+                        )
                     )
                     >> create_image
                 )
@@ -146,18 +151,21 @@ def create_restic_snapshot(ssh_conn_id, script_path, output_dir):
     with ssh_hook.get_conn() as ssh_client:
         with open("/home/ubuntu/restic_env.yaml", "r") as fobj:
             envs = yaml.load(fobj, Loader=yaml.FullLoader)
-        
+
         envs_str = " ".join([f"export {key}={value};" for key, value in envs.items()])
         print("Creating snapshot of downloaded images")
-        _, stdout, stderr = ssh_client.exec_command(f"{envs_str} sh {script_path} {output_dir}", 
-                                                    get_pty=True)
+        _, stdout, stderr = ssh_client.exec_command(
+            f"{envs_str} sh {script_path} {output_dir}", get_pty=True
+        )
 
         output = "\n".join(stdout.readlines())
         print(output)
 
         if stdout.channel.recv_exit_status() != 0:
             error_msg = "\n".join(stderr.readlines())
-            raise CreateSnapshotError(f"Creating snapshot failed with error:\n{error_msg}")
+            raise CreateSnapshotError(
+                f"Creating snapshot failed with error:\n{error_msg}"
+            )
 
 
 class CreateSnapshotError(Exception):


### PR DESCRIPTION
Added a task that automatically creates a snapshot of the freshly downloaded `squashfs` images. Additionally, fixed connecting to Puhti for key adding and fixed the Airflow installation URL that was recently updated.

The task assumes that there's an existing script  `create_snapshot.sh` in the home directory of our robot account, which there is. Not sure if it would be overkill to add an ansible task that makes sure that such script actually exists. At least it currently does and I don't see any reason why it would get deleted.