### PR TITLE
Bump minimum Ansible version requirement

### DIFF
--- a/ansible/requirements_dev.txt
+++ b/ansible/requirements_dev.txt
@@ -1,5 +1,5 @@
 python-openstackclient==3.14.3
 shade
-ansible>=2.9
+ansible>=2.10
 dnspython
 openstacksdk<=0.98.999


### PR DESCRIPTION
Installing collections from git repositories requires at least version 2.10. With older versions we get
```
$ ansible-galaxy collection install -r requirements.yml
Process install dependency map
ERROR! Invalid collection name 'git@github.com:CSCfi/Kielipankki-ansible-common.git', name must be in the format <namespace>.<collection>.
```
instead.