### PR TITLE
KP-6210 Download access images

### DIFF
--- a/harvester/file.py
+++ b/harvester/file.py
@@ -193,6 +193,27 @@ class ALTOFile(File):
         return Path(utils.binding_id_from_dc(self.binding_dc_identifier)) / "alto"
 
 
+class AccessImageFile(File):
+    """
+    A jpg file containing a scanned page/sheet from a binding
+    """
+
+    @property
+    def download_url(self):
+        """
+        The URL from which this file can be downloaded from NLF.
+
+        These are in consist of the full DC identifier (e.g.
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/1426186"), directory
+        "image" and the page number (e.g. "1"), no extension. The resulting URL will be
+        something like
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/1426186/image/1"
+        """
+        filename_root = Path(self.filename).stem
+        page_number = re.search(r"[1-9]\d*", filename_root).group(0)
+        return f"{self.binding_dc_identifier}/image/{page_number}"
+
+
 class METSLocationParseError(ValueError):
     """
     Exception raised when location of a file cannot be determined.

--- a/harvester/file.py
+++ b/harvester/file.py
@@ -66,8 +66,12 @@ class File:
 
         if filegrp_use in ["alto", "Text"] and filegrp_id == "ALTOGRP":
             file_cls = ALTOFile
+        elif filegrp_use in ["Images"] and filegrp_id == "IMGGRP":
+            file_cls = AccessImageFile
+        elif filegrp_id in ["TARGETIMGGRP", "RETAINEDIMGGRP", "MISSINGIMGGRP"]:
+            file_cls = SkippedFile
         else:
-            file_cls = UnknownTypeFile
+            raise UnknownFileException
 
         return file_cls(
             checksum=file_element.attrib["CHECKSUM"],
@@ -147,11 +151,12 @@ class File:
                 output_file.write(chunk)
 
 
-class UnknownTypeFile(File):
+class SkippedFile(File):
     """
-    Temporary class for files whose type is not known.
+    A class for files that are listed in METS but do not need download logic.
 
-    To be deleted when we figure out the file type detection.
+    These can be e.g. versions of scanned pages with rulers etc present in the image,
+    that are not normally available for users.
     """
 
 
@@ -217,4 +222,10 @@ class AccessImageFile(File):
 class METSLocationParseError(ValueError):
     """
     Exception raised when location of a file cannot be determined.
+    """
+
+
+class UnknownFileException(ValueError):
+    """
+    Exception raised when the file corresponding to a File element cannot be determined
     """

--- a/harvester/file.py
+++ b/harvester/file.py
@@ -61,10 +61,10 @@ class File:
         location = file_element.xpath("./*/@*[local-name()='href']")[0]
         parent = file_element.getparent()
 
-        if (
-            parent.attrib["USE"] in ["alto", "Text"]
-            and parent.attrib["ID"] == "ALTOGRP"
-        ):
+        filegrp_use = parent.attrib["USE"]
+        filegrp_id = parent.attrib["ID"]
+
+        if filegrp_use in ["alto", "Text"] and filegrp_id == "ALTOGRP":
             file_cls = ALTOFile
         else:
             file_cls = UnknownTypeFile

--- a/harvester/file.py
+++ b/harvester/file.py
@@ -71,7 +71,10 @@ class File:
         elif filegrp_id in ["TARGETIMGGRP", "RETAINEDIMGGRP", "MISSINGIMGGRP"]:
             file_cls = SkippedFile
         else:
-            raise UnknownFileException
+            raise UnknownFileException(
+                f"Unexpected fileGrp with ID {filegrp_id} and USE {filegrp_use} "
+                f"encountered"
+            )
 
         return file_cls(
             checksum=file_element.attrib["CHECKSUM"],

--- a/harvester/file.py
+++ b/harvester/file.py
@@ -71,7 +71,14 @@ class File:
             "ACIMGGRP",
         ]:
             file_cls = AccessImageFile
-        elif filegrp_id in ["TARGETIMGGRP", "RETAINEDIMGGRP", "MISSINGIMGGRP"]:
+        elif filegrp_id in [
+            "TARGETIMGGRP",
+            "RETAINEDIMGGRP",
+            "MISSINGIMGGRP",
+            "MAIMGGRP",
+            "TNIMGGRP",
+            "PDF",
+        ]:
             file_cls = SkippedFile
         else:
             raise UnknownFileException(

--- a/harvester/file.py
+++ b/harvester/file.py
@@ -66,7 +66,10 @@ class File:
 
         if filegrp_use in ["alto", "Text"] and filegrp_id == "ALTOGRP":
             file_cls = ALTOFile
-        elif filegrp_use in ["Images"] and filegrp_id == "IMGGRP":
+        elif filegrp_use in ["Images", "reference"] and filegrp_id in [
+            "IMGGRP",
+            "ACIMGGRP",
+        ]:
             file_cls = AccessImageFile
         elif filegrp_id in ["TARGETIMGGRP", "RETAINEDIMGGRP", "MISSINGIMGGRP"]:
             file_cls = SkippedFile

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -292,7 +292,7 @@ class PrepareDownloadLocationOperator(BaseOperator):
         with ssh_hook.get_conn() as ssh_client:
             sftp_client = ssh_client.open_sftp()
             for dirpath in self.ensure_dirs:
-                self.create_target_folder(sftp_client, dirpath)
+                self.create_directory(sftp_client, dirpath)
 
 
 class CreateTargetOperator(BaseOperator):

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -12,6 +12,7 @@ from harvester import utils
 from operators.file_download_operators import (
     SaveMetsSFTPOperator,
     SaveAltosSFTPOperator,
+    SaveAccessImagesSFTPOperator,
     DownloadBatchError,
 )
 
@@ -206,6 +207,17 @@ class StowBindingBatchOperator(BaseOperator):
                     ignore_files_set={},
                 )
                 self.execute_save_files_operator(alto_operator, context)
+
+                access_image_operator = SaveAccessImagesSFTPOperator(
+                    task_id=f"save_acces_images_{binding_id}",
+                    mets_path=mets_operator.output_file,
+                    sftp_client=sftp_client,
+                    ssh_client=ssh_client,
+                    dc_identifier=dc_identifier,
+                    output_directory=tmp_binding_path / "access_img",
+                    ignore_files_set={},
+                )
+                self.execute_save_files_operator(access_image_operator, context)
 
                 if self.temporary_files_present(ssh_client, tmp_binding_path):
                     raise DownloadBatchError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 import requests_mock
 
-from harvester.file import ALTOFile
+from harvester.file import ALTOFile, AccessImageFile
 
 
 @pytest.fixture(autouse=True)
@@ -287,3 +287,38 @@ def mock_alto_download_for_test_mets():
             content=alto_file_content.encode("utf-8"),
         )
         yield alto_file_content
+
+
+@pytest.fixture
+def access_image_url():
+    """
+    Return the expected download URL for an access image
+    """
+    return "https://example.com/1234/image/1"
+
+
+@pytest.fixture
+def access_image_binding_dc():
+    return "https://example.com/1234"
+
+
+@pytest.fixture
+def access_image_base_url():
+    return "https://example.com/1234/image"
+
+
+@pytest.fixture
+def access_image(access_image_binding_dc):
+    """
+    Factory for ALTOFiles with desired file names for testing.
+    """
+
+    def image_factory(filename):
+        return AccessImageFile(
+            "test_checksum",
+            "test_algo",
+            f"file://./preservation_img/{filename}",
+            access_image_binding_dc,
+        )
+
+    return image_factory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -290,6 +290,25 @@ def mock_alto_download_for_test_mets():
 
 
 @pytest.fixture
+def mock_access_image_download_for_test_mets(mets_dc_identifier):
+    """
+    Fake a response for GETting access images from "NLF".
+
+    We don't really need the proper images, so the response contains dummy binary data.
+    The "default" test METS represents a binding with four pages, so an image download
+    url is mocked for each of them.
+    """
+    file_content = "this is totally an image".encode("ascii")
+    with requests_mock.Mocker() as mocker:
+        for page_number in range(5):
+            mocker.get(
+                f"{mets_dc_identifier}/image/{page_number}",
+                content=file_content,
+            )
+        yield file_content
+
+
+@pytest.fixture
 def access_image_url():
     """
     Return the expected download URL for an access image

--- a/tests/data/exotic_files_METS.xml
+++ b/tests/data/exotic_files_METS.xml
@@ -1,0 +1,502 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- NB: this is not a full METS file: only fileSec/fileGrp/File elements and their corresponding amdSec elements are present -->
+<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/METS/" xsi:schemaLocation="http://www.loc.gov/METS/ //Themis/docworks/docWORKS/schema/mets-metae.xsd" xmlns:MODS="http://www.loc.gov/mods/v3" xmlns:mix="http://www.loc.gov/mix/" xmlns:xlink="http://www.w3.org/TR/xlink" TYPE="Newspaper" LABEL="Uusi Suometar no. 254 02.11.1885">
+	<metsHdr CREATEDATE="2007-08-14T11:14:02" LASTMODDATE="2007-08-14T11:14:02">
+		<agent ROLE="CREATOR" TYPE="OTHER" OTHERTYPE="SOFTWARE">
+			<name>CCS docWORKS/METAe Version 6.0-8</name>
+		</agent>
+	</metsHdr>
+	<amdSec ID="IMGPARAM00001">
+		<techMD ID="IMGPARAM00001TECHMD">
+			<mdWrap MDTYPE="NISOIMG">
+				<xmlData>
+					<mix:mix>
+						<mix:BasicImageParameters>
+							<mix:Format>
+								<mix:MIMEType>image/jp2</mix:MIMEType>
+								<mix:ByteOrder>little-endian</mix:ByteOrder>
+								<mix:Compression>
+									<mix:CompressionScheme>34712</mix:CompressionScheme>
+								</mix:Compression>
+								<mix:PhotometricInterpretation>
+									<mix:ColorSpace>1</mix:ColorSpace>
+								</mix:PhotometricInterpretation>
+							</mix:Format>
+							<mix:File>
+								<mix:ImageIdentifier imageIdentifierLocation="./preservation_img">pr-00001.jp2</mix:ImageIdentifier>
+								<mix:FileSize>7310297</mix:FileSize>
+								<mix:Orientation>1</mix:Orientation>
+								<mix:DisplayOrientation>1</mix:DisplayOrientation>
+							</mix:File>
+						</mix:BasicImageParameters>
+						<mix:ImageCreation>
+							<mix:SourceType>Newspaper</mix:SourceType>
+							<mix:SourceID/>
+							<mix:ImageProducer/>
+							<mix:Host>
+								<mix:HostComputer>DW04</mix:HostComputer>
+								<mix:OperatingSystem>windows</mix:OperatingSystem>
+								<mix:OSVersion>5.1 Service Pack 2</mix:OSVersion>
+							</mix:Host>
+							<mix:DeviceSource/>
+							<mix:ScanningSystemCapture>
+								<mix:ScanningSystemHardware>
+									<mix:ScannerManufacturer/>
+									<mix:ScannerModel>
+										<mix:ScannerModelName/>
+										<mix:ScannerModelNumber/>
+										<mix:ScannerModelSerialNo/>
+									</mix:ScannerModel>
+								</mix:ScanningSystemHardware>
+								<mix:ScanningSystemSoftware>
+									<mix:ScanningSoftware>CCS docWORKS</mix:ScanningSoftware>
+									<mix:ScanningSoftwareVersionNo/>
+								</mix:ScanningSystemSoftware>
+								<mix:ScannerCaptureSettings>
+									<mix:PixelSize>0.0846666</mix:PixelSize>
+									<mix:PhysScanResolution>
+										<mix:XphysScanResolution>300</mix:XphysScanResolution>
+										<mix:YphysScanResolution>300</mix:YphysScanResolution>
+									</mix:PhysScanResolution>
+								</mix:ScannerCaptureSettings>
+							</mix:ScanningSystemCapture>
+						</mix:ImageCreation>
+						<mix:ImagingPerformanceAssessment>
+							<mix:SpatialMetrics>
+								<mix:ImageWidth>7192</mix:ImageWidth>
+								<mix:ImageLength>2256</mix:ImageLength>
+							</mix:SpatialMetrics>
+							<mix:Energetics>
+								<mix:BitsPerSample>8</mix:BitsPerSample>
+								<mix:SamplesPerPixel>1</mix:SamplesPerPixel>
+							</mix:Energetics>
+						</mix:ImagingPerformanceAssessment>
+						<mix:ChangeHistory>
+							<mix:ImageProcessing>
+								<mix:SourceData>./54/EF9254/0443.jp2</mix:SourceData>
+							</mix:ImageProcessing>
+						</mix:ChangeHistory>
+					</mix:mix>
+				</xmlData>
+			</mdWrap>
+		</techMD>
+	</amdSec>
+	<amdSec ID="IMGPARAM00002">
+		<techMD ID="IMGPARAM00002TECHMD">
+			<mdWrap MDTYPE="NISOIMG">
+				<xmlData>
+					<mix:mix>
+						<mix:BasicImageParameters>
+							<mix:Format>
+								<mix:MIMEType>image/jp2</mix:MIMEType>
+								<mix:ByteOrder>little-endian</mix:ByteOrder>
+								<mix:Compression>
+									<mix:CompressionScheme>34712</mix:CompressionScheme>
+								</mix:Compression>
+								<mix:PhotometricInterpretation>
+									<mix:ColorSpace>1</mix:ColorSpace>
+								</mix:PhotometricInterpretation>
+							</mix:Format>
+							<mix:File>
+								<mix:ImageIdentifier imageIdentifierLocation="./preservation_img">pr-00002.jp2</mix:ImageIdentifier>
+								<mix:FileSize>18907022</mix:FileSize>
+								<mix:Orientation>1</mix:Orientation>
+								<mix:DisplayOrientation>1</mix:DisplayOrientation>
+							</mix:File>
+						</mix:BasicImageParameters>
+						<mix:ImageCreation>
+							<mix:SourceType>Newspaper</mix:SourceType>
+							<mix:SourceID/>
+							<mix:ImageProducer/>
+							<mix:Host>
+								<mix:HostComputer>DW04</mix:HostComputer>
+								<mix:OperatingSystem>windows</mix:OperatingSystem>
+								<mix:OSVersion>5.1 Service Pack 2</mix:OSVersion>
+							</mix:Host>
+							<mix:DeviceSource/>
+							<mix:ScanningSystemCapture>
+								<mix:ScanningSystemHardware>
+									<mix:ScannerManufacturer/>
+									<mix:ScannerModel>
+										<mix:ScannerModelName/>
+										<mix:ScannerModelNumber/>
+										<mix:ScannerModelSerialNo/>
+									</mix:ScannerModel>
+								</mix:ScanningSystemHardware>
+								<mix:ScanningSystemSoftware>
+									<mix:ScanningSoftware>CCS docWORKS</mix:ScanningSoftware>
+									<mix:ScanningSoftwareVersionNo/>
+								</mix:ScanningSystemSoftware>
+								<mix:ScannerCaptureSettings>
+									<mix:PixelSize>0.0846666</mix:PixelSize>
+									<mix:PhysScanResolution>
+										<mix:XphysScanResolution>300</mix:XphysScanResolution>
+										<mix:YphysScanResolution>300</mix:YphysScanResolution>
+									</mix:PhysScanResolution>
+								</mix:ScannerCaptureSettings>
+							</mix:ScanningSystemCapture>
+						</mix:ImageCreation>
+						<mix:ImagingPerformanceAssessment>
+							<mix:SpatialMetrics>
+								<mix:ImageWidth>5882</mix:ImageWidth>
+								<mix:ImageLength>8870</mix:ImageLength>
+							</mix:SpatialMetrics>
+							<mix:Energetics>
+								<mix:BitsPerSample>8</mix:BitsPerSample>
+								<mix:SamplesPerPixel>1</mix:SamplesPerPixel>
+							</mix:Energetics>
+						</mix:ImagingPerformanceAssessment>
+						<mix:ChangeHistory>
+							<mix:ImageProcessing>
+								<mix:SourceData>./54/EF9254/0444.jp2</mix:SourceData>
+							</mix:ImageProcessing>
+						</mix:ChangeHistory>
+					</mix:mix>
+				</xmlData>
+			</mdWrap>
+		</techMD>
+	</amdSec>
+	<amdSec ID="IMGPARAM00003">
+		<techMD ID="IMGPARAM00003TECHMD">
+			<mdWrap MDTYPE="NISOIMG">
+				<xmlData>
+					<mix:mix>
+						<mix:BasicImageParameters>
+							<mix:Format>
+								<mix:MIMEType>image/jp2</mix:MIMEType>
+								<mix:ByteOrder>little-endian</mix:ByteOrder>
+								<mix:Compression>
+									<mix:CompressionScheme>34712</mix:CompressionScheme>
+								</mix:Compression>
+								<mix:PhotometricInterpretation>
+									<mix:ColorSpace>1</mix:ColorSpace>
+								</mix:PhotometricInterpretation>
+							</mix:Format>
+							<mix:File>
+								<mix:ImageIdentifier imageIdentifierLocation="./preservation_img">pr-00003.jp2</mix:ImageIdentifier>
+								<mix:FileSize>19265920</mix:FileSize>
+								<mix:Orientation>1</mix:Orientation>
+								<mix:DisplayOrientation>1</mix:DisplayOrientation>
+							</mix:File>
+						</mix:BasicImageParameters>
+						<mix:ImageCreation>
+							<mix:SourceType>Newspaper</mix:SourceType>
+							<mix:SourceID/>
+							<mix:ImageProducer/>
+							<mix:Host>
+								<mix:HostComputer>DW04</mix:HostComputer>
+								<mix:OperatingSystem>windows</mix:OperatingSystem>
+								<mix:OSVersion>5.1 Service Pack 2</mix:OSVersion>
+							</mix:Host>
+							<mix:DeviceSource/>
+							<mix:ScanningSystemCapture>
+								<mix:ScanningSystemHardware>
+									<mix:ScannerManufacturer/>
+									<mix:ScannerModel>
+										<mix:ScannerModelName/>
+										<mix:ScannerModelNumber/>
+										<mix:ScannerModelSerialNo/>
+									</mix:ScannerModel>
+								</mix:ScanningSystemHardware>
+								<mix:ScanningSystemSoftware>
+									<mix:ScanningSoftware>CCS docWORKS</mix:ScanningSoftware>
+									<mix:ScanningSoftwareVersionNo/>
+								</mix:ScanningSystemSoftware>
+								<mix:ScannerCaptureSettings>
+									<mix:PixelSize>0.0846666</mix:PixelSize>
+									<mix:PhysScanResolution>
+										<mix:XphysScanResolution>300</mix:XphysScanResolution>
+										<mix:YphysScanResolution>300</mix:YphysScanResolution>
+									</mix:PhysScanResolution>
+								</mix:ScannerCaptureSettings>
+							</mix:ScanningSystemCapture>
+						</mix:ImageCreation>
+						<mix:ImagingPerformanceAssessment>
+							<mix:SpatialMetrics>
+								<mix:ImageWidth>5882</mix:ImageWidth>
+								<mix:ImageLength>8870</mix:ImageLength>
+							</mix:SpatialMetrics>
+							<mix:Energetics>
+								<mix:BitsPerSample>8</mix:BitsPerSample>
+								<mix:SamplesPerPixel>1</mix:SamplesPerPixel>
+							</mix:Energetics>
+						</mix:ImagingPerformanceAssessment>
+						<mix:ChangeHistory>
+							<mix:ImageProcessing>
+								<mix:SourceData>./54/EF9254/0445.jp2</mix:SourceData>
+							</mix:ImageProcessing>
+						</mix:ChangeHistory>
+					</mix:mix>
+				</xmlData>
+			</mdWrap>
+		</techMD>
+	</amdSec>
+	<amdSec ID="IMGPARAM00004">
+		<techMD ID="IMGPARAM00004TECHMD">
+			<mdWrap MDTYPE="NISOIMG">
+				<xmlData>
+					<mix:mix>
+						<mix:BasicImageParameters>
+							<mix:Format>
+								<mix:MIMEType>image/jp2</mix:MIMEType>
+								<mix:ByteOrder>little-endian</mix:ByteOrder>
+								<mix:Compression>
+									<mix:CompressionScheme>34712</mix:CompressionScheme>
+								</mix:Compression>
+								<mix:PhotometricInterpretation>
+									<mix:ColorSpace>1</mix:ColorSpace>
+								</mix:PhotometricInterpretation>
+							</mix:Format>
+							<mix:File>
+								<mix:ImageIdentifier imageIdentifierLocation="./preservation_img">pr-00004.jp2</mix:ImageIdentifier>
+								<mix:FileSize>19338039</mix:FileSize>
+								<mix:Orientation>1</mix:Orientation>
+								<mix:DisplayOrientation>1</mix:DisplayOrientation>
+							</mix:File>
+						</mix:BasicImageParameters>
+						<mix:ImageCreation>
+							<mix:SourceType>Newspaper</mix:SourceType>
+							<mix:SourceID/>
+							<mix:ImageProducer/>
+							<mix:Host>
+								<mix:HostComputer>DW04</mix:HostComputer>
+								<mix:OperatingSystem>windows</mix:OperatingSystem>
+								<mix:OSVersion>5.1 Service Pack 2</mix:OSVersion>
+							</mix:Host>
+							<mix:DeviceSource/>
+							<mix:ScanningSystemCapture>
+								<mix:ScanningSystemHardware>
+									<mix:ScannerManufacturer/>
+									<mix:ScannerModel>
+										<mix:ScannerModelName/>
+										<mix:ScannerModelNumber/>
+										<mix:ScannerModelSerialNo/>
+									</mix:ScannerModel>
+								</mix:ScanningSystemHardware>
+								<mix:ScanningSystemSoftware>
+									<mix:ScanningSoftware>CCS docWORKS</mix:ScanningSoftware>
+									<mix:ScanningSoftwareVersionNo/>
+								</mix:ScanningSystemSoftware>
+								<mix:ScannerCaptureSettings>
+									<mix:PixelSize>0.0846666</mix:PixelSize>
+									<mix:PhysScanResolution>
+										<mix:XphysScanResolution>300</mix:XphysScanResolution>
+										<mix:YphysScanResolution>300</mix:YphysScanResolution>
+									</mix:PhysScanResolution>
+								</mix:ScannerCaptureSettings>
+							</mix:ScanningSystemCapture>
+						</mix:ImageCreation>
+						<mix:ImagingPerformanceAssessment>
+							<mix:SpatialMetrics>
+								<mix:ImageWidth>5882</mix:ImageWidth>
+								<mix:ImageLength>8870</mix:ImageLength>
+							</mix:SpatialMetrics>
+							<mix:Energetics>
+								<mix:BitsPerSample>8</mix:BitsPerSample>
+								<mix:SamplesPerPixel>1</mix:SamplesPerPixel>
+							</mix:Energetics>
+						</mix:ImagingPerformanceAssessment>
+						<mix:ChangeHistory>
+							<mix:ImageProcessing>
+								<mix:SourceData>./54/EF9254/0446.jp2</mix:SourceData>
+							</mix:ImageProcessing>
+						</mix:ChangeHistory>
+					</mix:mix>
+				</xmlData>
+			</mdWrap>
+		</techMD>
+	</amdSec>
+	<amdSec ID="IMGPARAM00005">
+		<techMD ID="IMGPARAM00005TECHMD">
+			<mdWrap MDTYPE="NISOIMG">
+				<xmlData>
+					<mix:mix>
+						<mix:BasicImageParameters>
+							<mix:Format>
+								<mix:MIMEType>image/jp2</mix:MIMEType>
+								<mix:ByteOrder>little-endian</mix:ByteOrder>
+								<mix:Compression>
+									<mix:CompressionScheme>34712</mix:CompressionScheme>
+								</mix:Compression>
+								<mix:PhotometricInterpretation>
+									<mix:ColorSpace>1</mix:ColorSpace>
+								</mix:PhotometricInterpretation>
+							</mix:Format>
+							<mix:File>
+								<mix:ImageIdentifier imageIdentifierLocation="./preservation_img">pr-00005.jp2</mix:ImageIdentifier>
+								<mix:FileSize>18583745</mix:FileSize>
+								<mix:Orientation>1</mix:Orientation>
+								<mix:DisplayOrientation>1</mix:DisplayOrientation>
+							</mix:File>
+						</mix:BasicImageParameters>
+						<mix:ImageCreation>
+							<mix:SourceType>Newspaper</mix:SourceType>
+							<mix:SourceID/>
+							<mix:ImageProducer/>
+							<mix:Host>
+								<mix:HostComputer>DW04</mix:HostComputer>
+								<mix:OperatingSystem>windows</mix:OperatingSystem>
+								<mix:OSVersion>5.1 Service Pack 2</mix:OSVersion>
+							</mix:Host>
+							<mix:DeviceSource/>
+							<mix:ScanningSystemCapture>
+								<mix:ScanningSystemHardware>
+									<mix:ScannerManufacturer/>
+									<mix:ScannerModel>
+										<mix:ScannerModelName/>
+										<mix:ScannerModelNumber/>
+										<mix:ScannerModelSerialNo/>
+									</mix:ScannerModel>
+								</mix:ScanningSystemHardware>
+								<mix:ScanningSystemSoftware>
+									<mix:ScanningSoftware>CCS docWORKS</mix:ScanningSoftware>
+									<mix:ScanningSoftwareVersionNo/>
+								</mix:ScanningSystemSoftware>
+								<mix:ScannerCaptureSettings>
+									<mix:PixelSize>0.0846666</mix:PixelSize>
+									<mix:PhysScanResolution>
+										<mix:XphysScanResolution>300</mix:XphysScanResolution>
+										<mix:YphysScanResolution>300</mix:YphysScanResolution>
+									</mix:PhysScanResolution>
+								</mix:ScannerCaptureSettings>
+							</mix:ScanningSystemCapture>
+						</mix:ImageCreation>
+						<mix:ImagingPerformanceAssessment>
+							<mix:SpatialMetrics>
+								<mix:ImageWidth>5882</mix:ImageWidth>
+								<mix:ImageLength>8870</mix:ImageLength>
+							</mix:SpatialMetrics>
+							<mix:Energetics>
+								<mix:BitsPerSample>8</mix:BitsPerSample>
+								<mix:SamplesPerPixel>1</mix:SamplesPerPixel>
+							</mix:Energetics>
+						</mix:ImagingPerformanceAssessment>
+						<mix:ChangeHistory>
+							<mix:ImageProcessing>
+								<mix:SourceData>./54/EF9254/0447.jp2</mix:SourceData>
+							</mix:ImageProcessing>
+						</mix:ChangeHistory>
+					</mix:mix>
+				</xmlData>
+			</mdWrap>
+		</techMD>
+	</amdSec>
+	<amdSec ID="IMGPARAM00006">
+		<techMD ID="IMGPARAM00006TECHMD">
+			<mdWrap MDTYPE="NISOIMG">
+				<xmlData>
+					<mix:mix>
+						<mix:BasicImageParameters>
+							<mix:Format>
+								<mix:MIMEType>image/jp2</mix:MIMEType>
+								<mix:ByteOrder>little-endian</mix:ByteOrder>
+								<mix:Compression>
+									<mix:CompressionScheme>34712</mix:CompressionScheme>
+								</mix:Compression>
+								<mix:PhotometricInterpretation>
+									<mix:ColorSpace>1</mix:ColorSpace>
+								</mix:PhotometricInterpretation>
+							</mix:Format>
+							<mix:File>
+								<mix:ImageIdentifier imageIdentifierLocation="./preservation_img">pr-00006.jp2</mix:ImageIdentifier>
+								<mix:FileSize>18545641</mix:FileSize>
+								<mix:Orientation>1</mix:Orientation>
+								<mix:DisplayOrientation>1</mix:DisplayOrientation>
+							</mix:File>
+						</mix:BasicImageParameters>
+						<mix:ImageCreation>
+							<mix:SourceType>Newspaper</mix:SourceType>
+							<mix:SourceID/>
+							<mix:ImageProducer/>
+							<mix:Host>
+								<mix:HostComputer>DW04</mix:HostComputer>
+								<mix:OperatingSystem>windows</mix:OperatingSystem>
+								<mix:OSVersion>5.1 Service Pack 2</mix:OSVersion>
+							</mix:Host>
+							<mix:DeviceSource/>
+							<mix:ScanningSystemCapture>
+								<mix:ScanningSystemHardware>
+									<mix:ScannerManufacturer/>
+									<mix:ScannerModel>
+										<mix:ScannerModelName/>
+										<mix:ScannerModelNumber/>
+										<mix:ScannerModelSerialNo/>
+									</mix:ScannerModel>
+								</mix:ScanningSystemHardware>
+								<mix:ScanningSystemSoftware>
+									<mix:ScanningSoftware>CCS docWORKS</mix:ScanningSoftware>
+									<mix:ScanningSoftwareVersionNo/>
+								</mix:ScanningSystemSoftware>
+								<mix:ScannerCaptureSettings>
+									<mix:PixelSize>0.0846666</mix:PixelSize>
+									<mix:PhysScanResolution>
+										<mix:XphysScanResolution>300</mix:XphysScanResolution>
+										<mix:YphysScanResolution>300</mix:YphysScanResolution>
+									</mix:PhysScanResolution>
+								</mix:ScannerCaptureSettings>
+							</mix:ScanningSystemCapture>
+						</mix:ImageCreation>
+						<mix:ImagingPerformanceAssessment>
+							<mix:SpatialMetrics>
+								<mix:ImageWidth>5882</mix:ImageWidth>
+								<mix:ImageLength>8870</mix:ImageLength>
+							</mix:SpatialMetrics>
+							<mix:Energetics>
+								<mix:BitsPerSample>8</mix:BitsPerSample>
+								<mix:SamplesPerPixel>1</mix:SamplesPerPixel>
+							</mix:Energetics>
+						</mix:ImagingPerformanceAssessment>
+						<mix:ChangeHistory>
+							<mix:ImageProcessing>
+								<mix:SourceData>./54/EF9254/0443.jp2</mix:SourceData>
+							</mix:ImageProcessing>
+						</mix:ChangeHistory>
+					</mix:mix>
+				</xmlData>
+			</mdWrap>
+		</techMD>
+	</amdSec>
+	<fileSec>
+		<fileGrp ID="IMGGRP" USE="Images">
+			<file ID="IMG00002" CREATED="2007-08-14T11:11:00" ADMID="IMGPARAM00002" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="a115e8149b7c7d87232245ccb90b98be" CHECKSUMTYPE="MD5" SIZE="18907022">
+				<FLocat LOCTYPE="URL" xlink:href="file://./preservation_img/pr-00002.jp2"/>
+			</file>
+			<file ID="IMG00003" CREATED="2007-08-14T11:11:47" ADMID="IMGPARAM00003" MIMETYPE="image/jp2" SEQ="2" CHECKSUM="1a9d926f1927abc749e2ddeefaf94832" CHECKSUMTYPE="MD5" SIZE="19265920">
+				<FLocat LOCTYPE="URL" xlink:href="file://./preservation_img/pr-00003.jp2"/>
+			</file>
+			<file ID="IMG00004" CREATED="2007-08-14T11:12:30" ADMID="IMGPARAM00004" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="af753258a1fb7cd8a5a2e355578f8031" CHECKSUMTYPE="MD5" SIZE="19338039">
+				<FLocat LOCTYPE="URL" xlink:href="file://./preservation_img/pr-00004.jp2"/>
+			</file>
+			<file ID="IMG00005" CREATED="2007-08-14T11:13:17" ADMID="IMGPARAM00005" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="cfe5c398a5e07b03b2da613c5fa9d41a" CHECKSUMTYPE="MD5" SIZE="18583745">
+				<FLocat LOCTYPE="URL" xlink:href="file://./preservation_img/pr-00005.jp2"/>
+			</file>
+		</fileGrp>
+		<fileGrp ID="ALTOGRP" USE="Text">
+			<file ID="ALTO00001" MIMETYPE="text/xml" CHECKSUM="056aee468f4f37e46ee840b9b1e2eee6" CHECKSUMTYPE="MD5" SIZE="1623">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/00001.xml"/>
+			</file>
+			<file ID="ALTO00002" MIMETYPE="text/xml" CHECKSUM="0d974131b05e226f3b1ade4f560090e2" CHECKSUMTYPE="MD5" SIZE="560559">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/00002.xml"/>
+			</file>
+			<file ID="ALTO00003" MIMETYPE="text/xml" CHECKSUM="fe3aa6c105ae3f1bed3e7dc18cf516e7" CHECKSUMTYPE="MD5" SIZE="720810">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/00003.xml"/>
+			</file>
+			<file ID="ALTO00004" MIMETYPE="text/xml" CHECKSUM="4f7867cfa9a4c2a6ec9e31934c58c627" CHECKSUMTYPE="MD5" SIZE="745662">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/00004.xml"/>
+			</file>
+			<file ID="ALTO00005" MIMETYPE="text/xml" CHECKSUM="1a84e524cbcb82d01d7269d4b2318822" CHECKSUMTYPE="MD5" SIZE="513437">
+				<FLocat LOCTYPE="URL" xlink:href="file://./alto/00005.xml"/>
+			</file>
+		</fileGrp>
+		<fileGrp ID="TARGETIMGGRP" USE="Target images">
+			<file ID="IMG00001" CREATED="2007-08-14T11:10:42" ADMID="IMGPARAM00001" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="e08336b318323b31e4a6cca80f1d46c6" CHECKSUMTYPE="MD5" SIZE="7310297">
+				<FLocat LOCTYPE="URL" xlink:href="file://./preservation_img/pr-00001.jp2"/>
+			</file>
+		</fileGrp>
+		<fileGrp ID="RETAINEDIMGGRP" USE="Retained images">
+			<file ID="IMG00006" CREATED="2007-08-14T12:26:07" ADMID="IMGPARAM00006" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="6ad183c996427b6fed36965594ccdc01" CHECKSUMTYPE="MD5" SIZE="18545641" DMDID="MODSMD_PAGE1">
+				<FLocat LOCTYPE="URL" xlink:href="file://./preservation_img/pr-00006.jp2"/>
+			</file>
+		</fileGrp>
+	</fileSec>
+</mets>

--- a/tests/harvester/test_file.py
+++ b/tests/harvester/test_file.py
@@ -118,3 +118,33 @@ def test_download_to_remote(alto_file, sftp_client, sftp_server, mock_alto_downl
 
     with sftp.file(str(output_path), "r") as file:
         assert file.read().decode("utf-8") == mock_alto_download
+
+
+def test_access_image_download_url(access_image, access_image_base_url):
+    """
+    Test that the most basic case of access image url parsing works
+    """
+    image = access_image(filename="pr-00001.tif")
+    assert image.download_url == access_image_base_url + "/1"
+
+
+def test_access_image_download_url_with_large_page_number(
+    access_image, access_image_base_url
+):
+    """
+    Test that URLs are parsed correctly when binding has a lot of pages
+    """
+    image = access_image(filename="pr-123456789.tif")
+    assert image.download_url == access_image_base_url + "/123456789"
+
+
+def test_access_image_download_url_with_zeros_in_page_number(
+    access_image, access_image_base_url
+):
+    """
+    Test that zeros in page number behave as expected:
+      * leading zeros are ignored
+      * other zeros (trailing and in the middle of the number) are included
+    """
+    image = access_image(filename="pr-012304560.tif")
+    assert image.download_url == access_image_base_url + "/12304560"


### PR DESCRIPTION
Using the extensibility enhancements from https://github.com/CSCfi/kielipankki-nlf-harvester/pull/49, this PR adds the new operator for downloading access images and incorporates it into the pipeline.

Access images are downloaded for each binding after ALTOs. Only METS file is required for a binding for access image download to be attempted: even if one or more ALTOs cannot be downloaded, access image download is attempted.

Now that we download both ALTO and access image files, we should no longer have "unaccounted" file types. Thus specific file groups (e.g. thumbnails, PDFs and target images) were explicitly set to be skipped, and if we encounter an unknown fileGrp ID/USE combination, an exception is raised. This shields us from accidentally skipping files that should be downloaded, as the fileGrp use is not fully consistent and access images can be at least in file groups with ID "IMGGRP" or "ACIMGGRP". As this has not been run on the full collection intended for download, it is still possible that we need to add new classification instructions later.

Manual testing on test enviroment confirms that access image files are indeed downloaded. When checking the temporary files during a download_binding_batch run, we can see that both single and multi page bindings get access images for each ALTO:
```
[robot_2006633_puhti@puhti-login12 robot_2006633_puhti]$ tree aj-test-tmp/
aj-test-tmp/
├── col-361_1
│   ├── batch_0
│   │   └── 1
│   │       └── 19
│   │           ├── 191
│   │           │   └── 1911
│   │           │       └── 19115
│   │           │           └── 191159
│   │           │               └── 1911598
│   │           │                   └── 1911598
│   │           │                       ├── access_img
│   │           │                       │   ├── img0001-access.jpg
│   │           │                       │   ├── img0002-access.jpg
│   │           │                       │   ├── img0003-access.jpg
│   │           │                       │   ├── ...
│   │           │                       │   ├── img0163-access.jpg
│   │           │                       │   └── img0164-access.jpg
│   │           │                       ├── alto
│   │           │                       │   ├── img0001-alto.xml
│   │           │                       │   ├── img0002-alto.xml
│   │           │                       │   ├── img0003-alto.xml
│   │           │                       │   ├── ...
│   │           │                       │   ├── img0163-alto.xml
│   │           │                       │   └── img0164-alto.xml
│   │           │                       └── mets
│   │           │                           └── 1911598_METS.xml
│   │           ├── 195
│   │           │   └── 1958
│   │           │       └── 19581
│   │           │           └── 195815
│   │           │               ├── 1958154
│   │           │               │   └── 1958154
│   │           │               │       ├── access_img
│   │           │               │       │   └── img0001-access.jpg
│   │           │               │       ├── alto
│   │           │               │       │   └── img0001-alto.xml
│   │           │               │       └── mets
│   │           │               │           └── 1958154_METS.xml
│   │           │               └── 1958155
│   │           │                   └── 1958155
│   │           │                       ├── access_img
│   │           │                       │   └── img0001-access.jpg
│   │           │                       ├── alto
│   │           │                       │   └── img0001-alto.xml
│   │           │                       └── mets
│   │           │                           └── 1958155_METS.xml
...
```
I also confirmed that access image for https://digi.kansalliskirjasto.fi/teos/binding/1965539?page=1 corresponds to the page shown in the web UI.