### PR TITLE
KP-7716 Fixes for doing the image run

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -45,7 +45,7 @@ authorized_users:
 servers:
   - name: "{{ pouta_instance_name }}"
     image: "{{ std_image }}"
-    flavor: standard.xlarge
+    flavor: standard.xxlarge
     key_name: "{{ project_key }}"
     security_groups: "{{ project_security_groups }}"
     meta:

--- a/ansible/roles/airflow-config/defaults/main.yml
+++ b/ansible/roles/airflow-config/defaults/main.yml
@@ -12,3 +12,6 @@ gunicorn_workers: 7  # gunicorn recommendation (2 x $num_cores) + 1 for a medium
 navbar_color: "#fff"
 email_on_retry: False
 email_on_failure: False  # consider making this/these True for prod instance when properly in production
+job_heartbeat_sec: 15
+scheduler_heartbeat_sec: 15
+scheduler_health_check_threshold: 90

--- a/ansible/roles/airflow-config/defaults/main.yml
+++ b/ansible/roles/airflow-config/defaults/main.yml
@@ -15,3 +15,4 @@ email_on_failure: False  # consider making this/these True for prod instance whe
 job_heartbeat_sec: 15
 scheduler_heartbeat_sec: 15
 scheduler_health_check_threshold: 90
+scheduler_zombie_task_threshold: 600

--- a/ansible/roles/airflow-config/defaults/main.yml
+++ b/ansible/roles/airflow-config/defaults/main.yml
@@ -1,6 +1,6 @@
 airflow_directory: "/home/{{ ansible_user }}/airflow"
 executor: LocalExecutor
-parallel_tasks: 6
+parallel_tasks: 8
 max_active_tasks_per_dag: 16  # Default value, likely too big for medium pouta?
 max_active_runs_per_dag: 16  # Default value, pretty big but on the other hand mostly relevant when backgilling?
 min_file_process_interval: 300

--- a/ansible/roles/airflow-config/defaults/main.yml
+++ b/ansible/roles/airflow-config/defaults/main.yml
@@ -14,5 +14,5 @@ email_on_retry: False
 email_on_failure: False  # consider making this/these True for prod instance when properly in production
 job_heartbeat_sec: 15
 scheduler_heartbeat_sec: 15
-scheduler_health_check_threshold: 90
+scheduler_health_check_threshold: 300
 scheduler_zombie_task_threshold: 600

--- a/ansible/roles/airflow-config/templates/airflow.cfg.j2
+++ b/ansible/roles/airflow-config/templates/airflow.cfg.j2
@@ -941,12 +941,12 @@ tls_key =
 # Task instances listen for external kill signal (when you clear tasks
 # from the CLI or the UI), this defines the frequency at which they should
 # listen (in seconds).
-job_heartbeat_sec = 5
+job_heartbeat_sec = {{ job_heartbeat_sec }}
 
 # The scheduler constantly tries to trigger new tasks (look at the
 # scheduler section in the docs for more information). This defines
 # how often the scheduler should run (in seconds).
-scheduler_heartbeat_sec = 5
+scheduler_heartbeat_sec = {{ scheduler_heartbeat_sec }}
 
 # The number of times to try to schedule each DAG file
 # -1 indicates unlimited number
@@ -979,7 +979,7 @@ pool_metrics_interval = 5.0
 # If the last scheduler heartbeat happened more than scheduler_health_check_threshold
 # ago (in seconds), scheduler is considered unhealthy.
 # This is used by the health check in the "/health" endpoint
-scheduler_health_check_threshold = 30
+scheduler_health_check_threshold = {{ scheduler_health_check_threshold }}
 
 # When you start a scheduler, airflow starts a tiny web server
 # subprocess to serve a health check if this is set to True
@@ -1038,7 +1038,7 @@ max_dagruns_per_loop_to_schedule = 20
 # Should the Task supervisor process perform a "mini scheduler" to attempt to schedule more tasks of the
 # same DAG. Leaving this on will mean tasks in the same DAG execute quicker, but might starve out other
 # dags in some circumstances
-schedule_after_task_execution = True
+schedule_after_task_execution = False
 
 # The scheduler can run multiple processes in parallel to parse dags.
 # This defines how many processes will run.

--- a/ansible/roles/airflow-config/templates/airflow.cfg.j2
+++ b/ansible/roles/airflow-config/templates/airflow.cfg.j2
@@ -996,7 +996,7 @@ child_process_log_directory = {{ airflow_directory }}/logs/scheduler
 # Local task jobs periodically heartbeat to the DB. If the job has
 # not heartbeat in this many seconds, the scheduler will mark the
 # associated task instance as failed and will re-schedule the task.
-scheduler_zombie_task_threshold = 300
+scheduler_zombie_task_threshold = {{ scheduler_zombie_task_threshold }}
 
 # How often (in seconds) should the scheduler check for zombie tasks.
 zombie_detection_interval = 10.0

--- a/ansible/roles/harvester-setup/templates/restic_env.yaml.j2
+++ b/ansible/roles/harvester-setup/templates/restic_env.yaml.j2
@@ -2,3 +2,4 @@ AWS_SECRET_ACCESS_KEY: {{ lookup('passwordstore', 'lb_passwords/airflow/aws_secr
 AWS_ACCESS_KEY_ID: {{ lookup('passwordstore', 'lb_passwords/airflow/aws_access_key_id') }}
 RESTIC_REPOSITORY: {{ restic_repository }}
 RESTIC_PASSWORD: {{ lookup('passwordstore', 'lb_passwords/airflow/restic_password') }}
+RESTIC_PACK_SIZE: 128

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -88,13 +88,13 @@ def binding_download_location(binding_id, depth=None):
     return os.path.join(*sub_dirs)
 
 
-def calculate_batch_size(col_size):
+def calculate_batch_size(subset_size):
     """
-    Return a suitable download batch size for a collection.
+    Return a suitable download batch size for a subset.
     """
-    if col_size < 500:
-        return min(col_size, 10)
-    if col_size < 50000:
+    if subset_size < 500:
+        return min(subset_size, 10)
+    if subset_size < 50000:
         return 30
     else:
         return 100
@@ -102,12 +102,12 @@ def calculate_batch_size(col_size):
 
 def split_into_download_batches(bindings):
     """
-    Split a collection into download batches.
+    Split a subset into download batches.
     Return a list of tuples, containing the batch itself and the batch index.
     """
-    col_size = len(bindings)
-    batch_size = calculate_batch_size(col_size)
-    batches = [bindings[i : i + batch_size] for i in range(0, col_size, batch_size)]
+    subset_size = len(bindings)
+    batch_size = calculate_batch_size(subset_size)
+    batches = [bindings[i : i + batch_size] for i in range(0, subset_size, batch_size)]
     return list(zip(batches, range(len(batches))))
 
 

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -95,11 +95,9 @@ def calculate_batch_size(col_size):
     if col_size < 500:
         return min(col_size, 10)
     if col_size < 50000:
-        return 100
-    if col_size < 500000:
-        return 500
+        return 30
     else:
-        return 2000
+        return 100
 
 
 def split_into_download_batches(bindings):

--- a/tests/harvester/test_utils.py
+++ b/tests/harvester/test_utils.py
@@ -38,9 +38,8 @@ def test_calculate_batch_size():
     """
     assert utils.calculate_batch_size(1) == 1
     assert utils.calculate_batch_size(100) == 10
-    assert utils.calculate_batch_size(10000) == 100
-    assert utils.calculate_batch_size(100000) == 500
-    assert utils.calculate_batch_size(1000000) == 2000
+    assert utils.calculate_batch_size(10000) == 30
+    assert utils.calculate_batch_size(100000) == 100
 
 
 def test_split_into_download_batches():


### PR DESCRIPTION
Batches of >=100 cause tasks to never finish if they have large bindings, because the scheduler will run out of memory before the task completes. Reduced the batch size so that it, combined with provisioning a beefier VM to run on, will hopefully let us finish a download that contains page images too.

I also made the collection vs subset naming more consistent: the utility functions that are only used with subsets no longer talk about collections.