### PR TITLE
KP-7610 Using SEQ attribute to determine page download URLs

### DIFF
--- a/harvester/file.py
+++ b/harvester/file.py
@@ -16,21 +16,15 @@ class File:
     A shared base class for files originating from NLF.
     """
 
-    def __init__(self, checksum, algorithm, location_xlink, binding_dc_identifier):
+    def __init__(self, location_xlink, binding_dc_identifier):
         """
         Create a new file
 
-        :param checksum: Checksum for the file
-        :type checksum: String
-        :param algorithm: Algorithm used when calculating the checksum, e.g. MD5
-        :type algorithm: String
         :param location_xlink: Location of the file as given in METS.
         :type location_xlink: String
         :param content_type: Type of information represented by this file.
         :type content_type: :class:`~harvester.file.ContentType`
         """
-        self.checksum = checksum
-        self.algorithm = algorithm
         self.location_xlink = location_xlink
         self.binding_dc_identifier = binding_dc_identifier
 
@@ -87,8 +81,6 @@ class File:
             )
 
         return file_cls(
-            checksum=file_element.attrib["CHECKSUM"],
-            algorithm=file_element.attrib["CHECKSUMTYPE"],
             location_xlink=location,
             binding_dc_identifier=binding_dc_identifier,
         )

--- a/harvester/mets.py
+++ b/harvester/mets.py
@@ -68,16 +68,7 @@ class METS:
     def _add_access_image_files(self, file_elements):
         """
         Add an AccessImageFile to self._files for every access image in file_elements
-
-        There doesn't seem to be a reliable way of matching the elements to the
-        digi.kansalliskirjasto.fi download URLs (at least the numeric part of file name
-        nor the SEQ numbers do not work), so creating the right number of files whose
-        page numbers go from 1 to n is prioritized. In all reviewed cases, this also
-        seems to be the right order, but this cannot be guaranteed. Fortunately all
-        files in a fileGrp have also always had the same file type extension (which is
-        the only part utilized from location_xlink).
         """
-        page_number = 1
         for file_element in file_elements:
             children = file_element.getchildren()
             if len(children) != 1:
@@ -94,6 +85,7 @@ class METS:
                 "IMGGRP",
                 "ACIMGGRP",
             ]:
+                page_number = int(file_element.attrib["SEQ"])
                 self._files.append(
                     AccessImageFile(
                         binding_dc_identifier=self.binding_dc_identifier,
@@ -101,7 +93,6 @@ class METS:
                         location_xlink=location,
                     )
                 )
-                page_number += 1
 
     def _add_alto_files_for_images(self):
         """

--- a/harvester/mets.py
+++ b/harvester/mets.py
@@ -68,7 +68,16 @@ class METS:
     def _add_access_image_files(self, file_elements):
         """
         Add an AccessImageFile to self._files for every access image in file_elements
+
+        There doesn't seem to be a reliable way of matching the elements to the
+        digi.kansalliskirjasto.fi download URLs (at least the numeric part of file name
+        nor the SEQ numbers do not work), so creating the right number of files whose
+        page numbers go from 1 to n is prioritized. In all reviewed cases, this also
+        seems to be the right order, but this cannot be guaranteed. Fortunately all
+        files in a fileGrp have also always had the same file type extension (which is
+        the only part utilized from location_xlink).
         """
+        page_number = 1
         for file_element in file_elements:
             children = file_element.getchildren()
             if len(children) != 1:
@@ -85,7 +94,6 @@ class METS:
                 "IMGGRP",
                 "ACIMGGRP",
             ]:
-                page_number = int(file_element.attrib["SEQ"])
                 self._files.append(
                     AccessImageFile(
                         binding_dc_identifier=self.binding_dc_identifier,
@@ -93,6 +101,7 @@ class METS:
                         location_xlink=location,
                     )
                 )
+                page_number += 1
 
     def _add_alto_files_for_images(self):
         """

--- a/harvester_cli.py
+++ b/harvester_cli.py
@@ -43,32 +43,6 @@ def binding_ids(set_id, url):
     "collection_dc_identifier",
 )
 @click.option("--encoding", default="utf-8")
-def checksums(mets_file_path, collection_dc_identifier, encoding):
-    """
-    Output checksums for all files listed in the METS document.
-
-    \b
-    METS_FILE_PATH:
-        Path to the METS file to be read
-
-    \b
-    COLLECTION_DC_IDENTIFIER:
-        Dublin Core identifier for the collection to
-        which the binding described by this METS belongs. E.g.
-        https://digi.kansalliskirjasto.fi/sanomalehti/binding/380082.
-    """
-    mets_file = open(mets_file_path, "rb")
-    mets = METS(collection_dc_identifier, mets_file=mets_file, encoding=encoding)
-    for file in mets.files():
-        click.echo(file.checksum)
-
-
-@cli.command
-@click.argument("mets_file_path")
-@click.argument(
-    "collection_dc_identifier",
-)
-@click.option("--encoding", default="utf-8")
 def list_download_urls(mets_file_path, collection_dc_identifier, encoding):
     """
     Print download URLs for all files in METS

--- a/pipeline/dags/download_collections.py
+++ b/pipeline/dags/download_collections.py
@@ -31,7 +31,7 @@ pathdict = {
 SSH_CONN_ID = "puhti_conn"
 HTTP_CONN_ID = "nlf_http_conn"
 COLLECTIONS = [
-    #    {"id": "col-361", "subset_size": 150},
+    #    {"id": "col-501", "subset_size": 1000},
     {"id": "col-861", "subset_size": 100000},
 ]
 

--- a/pipeline/dags/fetch_binding_ids.py
+++ b/pipeline/dags/fetch_binding_ids.py
@@ -14,7 +14,7 @@ from harvester.pmh_interface import PMH_API
 
 
 SET_IDS = [
-    "col-361",
+    "col-501",
     "col-861",
 ]
 BASE_PATH = Path("/home/ubuntu/binding_ids_all")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,22 +203,27 @@ def alto_url():
 
 
 @pytest.fixture()
-def alto_filename():
+def alto_pagenumber():
+    """
+    Return the page number for an ALTO test file
+    """
+    return 2
+
+
+@pytest.fixture()
+def alto_filename(alto_pagenumber):
     """
     Return the filename for an ALTO test file
     """
-    return "2.xml"
+    return f"0000{alto_pagenumber}.xml"
 
 
 @pytest.fixture
-def alto_file(alto_url, alto_filename):
+def alto_file(alto_url, alto_pagenumber):
     """
     Return an ALTOFile for testing.
     """
-    return ALTOFile(
-        f"file://./alto/{alto_filename}",
-        alto_url,
-    )
+    return ALTOFile(binding_dc_identifier=alto_url, page_number=alto_pagenumber)
 
 
 @pytest.fixture
@@ -233,18 +238,7 @@ def alto_file_with_erroneous_name(alto_url):
 
 
 @pytest.fixture
-def alto_file_with_parsable_name(alto_url):
-    """
-    Return an ALTOfile with a non-standard, but parsable and working filename.
-    """
-    return ALTOFile(
-        "file://./alto/img0001-alto.xml",
-        alto_url,
-    )
-
-
-@pytest.fixture
-def mock_alto_download(alto_url, alto_filename):
+def mock_alto_download(alto_url, alto_pagenumber):
     """
     Fake a response for GETting an ALTO file from "NLF".
 
@@ -254,7 +248,7 @@ def mock_alto_download(alto_url, alto_filename):
     alto_file_content = "<xml>test cöntent</xml>"
     with requests_mock.Mocker() as mocker:
         mocker.get(
-            f"{alto_url}/page-{alto_filename}",
+            f"{alto_url}/page-{alto_pagenumber}.xml",
             content=alto_file_content.encode("utf-8"),
         )
         yield alto_file_content
@@ -326,10 +320,11 @@ def access_image(access_image_binding_dc):
     Factory for ALTOFiles with desired file names for testing.
     """
 
-    def image_factory(filename):
+    def image_factory(page_number, extension):
         return AccessImageFile(
-            f"file://./preservation_img/{filename}",
-            access_image_binding_dc,
+            binding_dc_identifier=access_image_binding_dc,
+            page_number=page_number,
+            location_xlink=f"file://./preservation_img/{page_number}{extension}",
         )
 
     return image_factory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,8 +216,6 @@ def alto_file(alto_url, alto_filename):
     Return an ALTOFile for testing.
     """
     return ALTOFile(
-        "test_checksum",
-        "test_algo",
         f"file://./alto/{alto_filename}",
         alto_url,
     )
@@ -229,8 +227,6 @@ def alto_file_with_erroneous_name(alto_url):
     Return an ALTOFile with an erroneus filename for testing.
     """
     return ALTOFile(
-        "test_checksum",
-        "test_algo",
         "file://./alto/alto.xml",
         alto_url,
     )
@@ -242,8 +238,6 @@ def alto_file_with_parsable_name(alto_url):
     Return an ALTOfile with a non-standard, but parsable and working filename.
     """
     return ALTOFile(
-        "test_checksum",
-        "test_algo",
         "file://./alto/img0001-alto.xml",
         alto_url,
     )
@@ -334,8 +328,6 @@ def access_image(access_image_binding_dc):
 
     def image_factory(filename):
         return AccessImageFile(
-            "test_checksum",
-            "test_algo",
             f"file://./preservation_img/{filename}",
             access_image_binding_dc,
         )

--- a/tests/data/exotic_files_METS.xml
+++ b/tests/data/exotic_files_METS.xml
@@ -324,81 +324,6 @@
 							</mix:Format>
 							<mix:File>
 								<mix:ImageIdentifier imageIdentifierLocation="./preservation_img">pr-00005.jp2</mix:ImageIdentifier>
-								<mix:FileSize>18583745</mix:FileSize>
-								<mix:Orientation>1</mix:Orientation>
-								<mix:DisplayOrientation>1</mix:DisplayOrientation>
-							</mix:File>
-						</mix:BasicImageParameters>
-						<mix:ImageCreation>
-							<mix:SourceType>Newspaper</mix:SourceType>
-							<mix:SourceID/>
-							<mix:ImageProducer/>
-							<mix:Host>
-								<mix:HostComputer>DW04</mix:HostComputer>
-								<mix:OperatingSystem>windows</mix:OperatingSystem>
-								<mix:OSVersion>5.1 Service Pack 2</mix:OSVersion>
-							</mix:Host>
-							<mix:DeviceSource/>
-							<mix:ScanningSystemCapture>
-								<mix:ScanningSystemHardware>
-									<mix:ScannerManufacturer/>
-									<mix:ScannerModel>
-										<mix:ScannerModelName/>
-										<mix:ScannerModelNumber/>
-										<mix:ScannerModelSerialNo/>
-									</mix:ScannerModel>
-								</mix:ScanningSystemHardware>
-								<mix:ScanningSystemSoftware>
-									<mix:ScanningSoftware>CCS docWORKS</mix:ScanningSoftware>
-									<mix:ScanningSoftwareVersionNo/>
-								</mix:ScanningSystemSoftware>
-								<mix:ScannerCaptureSettings>
-									<mix:PixelSize>0.0846666</mix:PixelSize>
-									<mix:PhysScanResolution>
-										<mix:XphysScanResolution>300</mix:XphysScanResolution>
-										<mix:YphysScanResolution>300</mix:YphysScanResolution>
-									</mix:PhysScanResolution>
-								</mix:ScannerCaptureSettings>
-							</mix:ScanningSystemCapture>
-						</mix:ImageCreation>
-						<mix:ImagingPerformanceAssessment>
-							<mix:SpatialMetrics>
-								<mix:ImageWidth>5882</mix:ImageWidth>
-								<mix:ImageLength>8870</mix:ImageLength>
-							</mix:SpatialMetrics>
-							<mix:Energetics>
-								<mix:BitsPerSample>8</mix:BitsPerSample>
-								<mix:SamplesPerPixel>1</mix:SamplesPerPixel>
-							</mix:Energetics>
-						</mix:ImagingPerformanceAssessment>
-						<mix:ChangeHistory>
-							<mix:ImageProcessing>
-								<mix:SourceData>./54/EF9254/0447.jp2</mix:SourceData>
-							</mix:ImageProcessing>
-						</mix:ChangeHistory>
-					</mix:mix>
-				</xmlData>
-			</mdWrap>
-		</techMD>
-	</amdSec>
-	<amdSec ID="IMGPARAM00006">
-		<techMD ID="IMGPARAM00006TECHMD">
-			<mdWrap MDTYPE="NISOIMG">
-				<xmlData>
-					<mix:mix>
-						<mix:BasicImageParameters>
-							<mix:Format>
-								<mix:MIMEType>image/jp2</mix:MIMEType>
-								<mix:ByteOrder>little-endian</mix:ByteOrder>
-								<mix:Compression>
-									<mix:CompressionScheme>34712</mix:CompressionScheme>
-								</mix:Compression>
-								<mix:PhotometricInterpretation>
-									<mix:ColorSpace>1</mix:ColorSpace>
-								</mix:PhotometricInterpretation>
-							</mix:Format>
-							<mix:File>
-								<mix:ImageIdentifier imageIdentifierLocation="./preservation_img">pr-00006.jp2</mix:ImageIdentifier>
 								<mix:FileSize>18545641</mix:FileSize>
 								<mix:Orientation>1</mix:Orientation>
 								<mix:DisplayOrientation>1</mix:DisplayOrientation>
@@ -456,6 +381,81 @@
 			</mdWrap>
 		</techMD>
 	</amdSec>
+	<amdSec ID="IMGPARAM00006">
+		<techMD ID="IMGPARAM00006TECHMD">
+			<mdWrap MDTYPE="NISOIMG">
+				<xmlData>
+					<mix:mix>
+						<mix:BasicImageParameters>
+							<mix:Format>
+								<mix:MIMEType>image/jp2</mix:MIMEType>
+								<mix:ByteOrder>little-endian</mix:ByteOrder>
+								<mix:Compression>
+									<mix:CompressionScheme>34712</mix:CompressionScheme>
+								</mix:Compression>
+								<mix:PhotometricInterpretation>
+									<mix:ColorSpace>1</mix:ColorSpace>
+								</mix:PhotometricInterpretation>
+							</mix:Format>
+							<mix:File>
+								<mix:ImageIdentifier imageIdentifierLocation="./preservation_img">pr-00006.jp2</mix:ImageIdentifier>
+								<mix:FileSize>18583745</mix:FileSize>
+								<mix:Orientation>1</mix:Orientation>
+								<mix:DisplayOrientation>1</mix:DisplayOrientation>
+							</mix:File>
+						</mix:BasicImageParameters>
+						<mix:ImageCreation>
+							<mix:SourceType>Newspaper</mix:SourceType>
+							<mix:SourceID/>
+							<mix:ImageProducer/>
+							<mix:Host>
+								<mix:HostComputer>DW04</mix:HostComputer>
+								<mix:OperatingSystem>windows</mix:OperatingSystem>
+								<mix:OSVersion>5.1 Service Pack 2</mix:OSVersion>
+							</mix:Host>
+							<mix:DeviceSource/>
+							<mix:ScanningSystemCapture>
+								<mix:ScanningSystemHardware>
+									<mix:ScannerManufacturer/>
+									<mix:ScannerModel>
+										<mix:ScannerModelName/>
+										<mix:ScannerModelNumber/>
+										<mix:ScannerModelSerialNo/>
+									</mix:ScannerModel>
+								</mix:ScanningSystemHardware>
+								<mix:ScanningSystemSoftware>
+									<mix:ScanningSoftware>CCS docWORKS</mix:ScanningSoftware>
+									<mix:ScanningSoftwareVersionNo/>
+								</mix:ScanningSystemSoftware>
+								<mix:ScannerCaptureSettings>
+									<mix:PixelSize>0.0846666</mix:PixelSize>
+									<mix:PhysScanResolution>
+										<mix:XphysScanResolution>300</mix:XphysScanResolution>
+										<mix:YphysScanResolution>300</mix:YphysScanResolution>
+									</mix:PhysScanResolution>
+								</mix:ScannerCaptureSettings>
+							</mix:ScanningSystemCapture>
+						</mix:ImageCreation>
+						<mix:ImagingPerformanceAssessment>
+							<mix:SpatialMetrics>
+								<mix:ImageWidth>5882</mix:ImageWidth>
+								<mix:ImageLength>8870</mix:ImageLength>
+							</mix:SpatialMetrics>
+							<mix:Energetics>
+								<mix:BitsPerSample>8</mix:BitsPerSample>
+								<mix:SamplesPerPixel>1</mix:SamplesPerPixel>
+							</mix:Energetics>
+						</mix:ImagingPerformanceAssessment>
+						<mix:ChangeHistory>
+							<mix:ImageProcessing>
+								<mix:SourceData>./54/EF9254/0447.jp2</mix:SourceData>
+							</mix:ImageProcessing>
+						</mix:ChangeHistory>
+					</mix:mix>
+				</xmlData>
+			</mdWrap>
+		</techMD>
+	</amdSec>
 	<fileSec>
 		<fileGrp ID="IMGGRP" USE="Images">
 			<file ID="IMG00002" CREATED="2007-08-14T11:11:00" ADMID="IMGPARAM00002" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="a115e8149b7c7d87232245ccb90b98be" CHECKSUMTYPE="MD5" SIZE="18907022">
@@ -467,8 +467,8 @@
 			<file ID="IMG00004" CREATED="2007-08-14T11:12:30" ADMID="IMGPARAM00004" MIMETYPE="image/jp2" SEQ="3" CHECKSUM="af753258a1fb7cd8a5a2e355578f8031" CHECKSUMTYPE="MD5" SIZE="19338039">
 				<FLocat LOCTYPE="URL" xlink:href="file://./preservation_img/pr-00004.jp2"/>
 			</file>
-			<file ID="IMG00005" CREATED="2007-08-14T11:13:17" ADMID="IMGPARAM00005" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="cfe5c398a5e07b03b2da613c5fa9d41a" CHECKSUMTYPE="MD5" SIZE="18583745">
-				<FLocat LOCTYPE="URL" xlink:href="file://./preservation_img/pr-00005.jp2"/>
+      <file ID="IMG00006" CREATED="2007-08-14T11:13:17" ADMID="IMGPARAM00005" MIMETYPE="image/jp2" SEQ="4" CHECKSUM="cfe5c398a5e07b03b2da613c5fa9d41a" CHECKSUMTYPE="MD5" SIZE="18583745">
+				<FLocat LOCTYPE="URL" xlink:href="file://./preservation_img/pr-00006.jp2"/>
 			</file>
 		</fileGrp>
 		<fileGrp ID="ALTOGRP" USE="Text">
@@ -494,8 +494,8 @@
 			</file>
 		</fileGrp>
 		<fileGrp ID="RETAINEDIMGGRP" USE="Retained images">
-			<file ID="IMG00006" CREATED="2007-08-14T12:26:07" ADMID="IMGPARAM00006" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="6ad183c996427b6fed36965594ccdc01" CHECKSUMTYPE="MD5" SIZE="18545641" DMDID="MODSMD_PAGE1">
-				<FLocat LOCTYPE="URL" xlink:href="file://./preservation_img/pr-00006.jp2"/>
+			<file ID="IMG00005" CREATED="2007-08-14T12:26:07" ADMID="IMGPARAM00006" MIMETYPE="image/jp2" SEQ="1" CHECKSUM="6ad183c996427b6fed36965594ccdc01" CHECKSUMTYPE="MD5" SIZE="18545641" DMDID="MODSMD_PAGE1">
+				<FLocat LOCTYPE="URL" xlink:href="file://./preservation_img/pr-00005.jp2"/>
 			</file>
 		</fileGrp>
 	</fileSec>

--- a/tests/harvester/test_file.py
+++ b/tests/harvester/test_file.py
@@ -19,11 +19,7 @@ def test_file_initialized_values():
     """
     Check that the values given when initializing are utilized correctly
     """
-    test_file = File(
-        "test_checksum", "test_algo", "test_location", "test_dc_identifier"
-    )
-    assert test_file.checksum == "test_checksum"
-    assert test_file.algorithm == "test_algo"
+    test_file = File("test_location", "test_dc_identifier")
     assert test_file.location_xlink == "test_location"
     assert test_file.binding_dc_identifier == "test_dc_identifier"
 

--- a/tests/harvester/test_file.py
+++ b/tests/harvester/test_file.py
@@ -19,16 +19,16 @@ def test_file_initialized_values():
     """
     Check that the values given when initializing are utilized correctly
     """
-    test_file = File("test_location", "test_dc_identifier")
-    assert test_file.location_xlink == "test_location"
+    test_file = File(binding_dc_identifier="test_dc_identifier", page_number=123)
     assert test_file.binding_dc_identifier == "test_dc_identifier"
+    assert test_file.page_number == 123
 
 
-def test_alto_download_url(alto_file, alto_url, alto_filename):
+def test_alto_download_url(alto_file, alto_url, alto_pagenumber):
     """
     Ensure that the download URL is formed using the filename and dc_identifier.
     """
-    assert alto_file.download_url == f"{alto_url}/page-{alto_filename}"
+    assert alto_file.download_url == f"{alto_url}/page-{alto_pagenumber}.xml"
 
 
 def test_filename(alto_file, alto_filename):
@@ -36,24 +36,6 @@ def test_filename(alto_file, alto_filename):
     Ensure that determining the file name based on the xpath works.
     """
     assert alto_file.filename == alto_filename
-
-
-def test_erroneus_filename(alto_file_with_erroneous_name):
-    """
-    Ensure that an erroneous ALTO filename raises an error.
-    """
-    with pytest.raises(AttributeError, match=r".* alto.xml .*"):
-        alto_file_with_erroneous_name.download_url()
-
-
-def test_parsable_filename(alto_file_with_parsable_name):
-    """
-    Ensure that an ALTO file with a non-standard name gets parsed correctly.
-    """
-    assert (
-        alto_file_with_parsable_name.download_url.rsplit("/", maxsplit=1)[-1]
-        == "page-1.xml"
-    )
 
 
 def test_download_to_default_path(
@@ -120,7 +102,7 @@ def test_access_image_download_url(access_image, access_image_base_url):
     """
     Test that the most basic case of access image url parsing works
     """
-    image = access_image(filename="pr-00001.tif")
+    image = access_image(page_number=1, extension=".tif")
     assert image.download_url == access_image_base_url + "/1"
 
 
@@ -130,7 +112,7 @@ def test_access_image_download_url_with_large_page_number(
     """
     Test that URLs are parsed correctly when binding has a lot of pages
     """
-    image = access_image(filename="pr-123456789.tif")
+    image = access_image(page_number=123456789, extension=".jp2")
     assert image.download_url == access_image_base_url + "/123456789"
 
 
@@ -142,5 +124,5 @@ def test_access_image_download_url_with_zeros_in_page_number(
       * leading zeros are ignored
       * other zeros (trailing and in the middle of the number) are included
     """
-    image = access_image(filename="pr-012304560.tif")
+    image = access_image(page_number=12304560, extension=".tif")
     assert image.download_url == access_image_base_url + "/12304560"

--- a/tests/harvester/test_mets.py
+++ b/tests/harvester/test_mets.py
@@ -59,21 +59,6 @@ def mets_with_multiple_file_locations(simple_mets_path, tmp_path):
     return mets_output_path
 
 
-def test_file_checksum_parsing(simple_mets_object):
-    """
-    Test checksum parsing when there's one location for each file.
-    """
-    files = list(simple_mets_object.files())
-
-    first_file = files[0]
-    assert first_file.checksum == "ab64aff5f8375ca213eeaee260edcefe"
-    assert first_file.algorithm == "MD5"
-
-    last_file = files[-1]
-    assert last_file.checksum == "a462f99b087161579104902c19d7746d"
-    assert last_file.algorithm == "MD5"
-
-
 def test_file_location_parsing(simple_mets_object):
     """
     Test file location parsing when there's one location for each file.

--- a/tests/pipeline/test_file_download_operators.py
+++ b/tests/pipeline/test_file_download_operators.py
@@ -346,10 +346,10 @@ def test_save_access_images_sftp_operator(
         image_locations = [
             image_dir / filename
             for filename in [
-                "pr-00001.jp2",
-                "pr-00002.jp2",
-                "pr-00003.jp2",
-                "pr-00004.jp2",
+                "00001.jp2",
+                "00002.jp2",
+                "00003.jp2",
+                "00004.jp2",
             ]
         ]
 

--- a/tests/test_harvester_cli.py
+++ b/tests/test_harvester_cli.py
@@ -71,25 +71,6 @@ def test_binding_ids_from_default_url(two_page_pmh_response, two_page_set_id):
 
 
 @requires_37
-def test_checksums(simple_mets_path, mets_dc_identifier):
-    """
-    Check that at least one correct checksum is printed
-    """
-    runner = CliRunner()
-
-    result = runner.invoke(
-        cli,
-        [
-            "checksums",
-            simple_mets_path,
-            mets_dc_identifier,
-        ],
-        catch_exceptions=False,
-    )
-    assert "\n33cbc005ce7dac534bdcc424c8a082cd\n" in result.output
-
-
-@requires_37
 def test_list_download_urls(simple_mets_path):
     """
     Check that the CLI is able to call the `download_urls` function.


### PR DESCRIPTION
TL;DR:
- download URLs now based on page number, derived from SEQ attribute of   access image elements
- ALTOs created by creating an ALTO counterpart for each access image
- File naming changed: we now have 00001.xml and 00001.jp2 as opposed to  00001.xml and pr-00001.jp2
- No longer verifying that there are no unexpected file groups (none were found during the [KP-7716](https://jira.eduuni.fi/browse/KP-7716) run

Previously the download URLs for both ALTO and access image files were determined based on the file name in the METS file: e.g. image with file name "pr-00003.jp2" would get a download URL ending "/image/3". Unfortunately this does not always work, as there can be other files (target images etc) listed in METS with lower-numbered file names, or even file names between the actual pages. The digi.kansalliskirjasto.fi download URLs do not follow the file names though: the scanned image for the first page is always "/image/1" and the ALTO file for it "page-1.xml" and so on.

For access images, it's easy to fix this discrepancy: each of their file elements in METS has a SEQ attribute that corresponds to the page number. For ALTOs, this is not as simple: they don't have SEQ attribute and the same file group contais OCRs for both the actual page scans and other files such as target images.

Thus, the METS parsing was updated so that first all access image files are extracted, and then an ALTO file is generated for each of them. This means that no information directly from the file elements for ALTO files is actually used. If such functionality was desired (e.g. if we start verifying download checksums), it would likely require matching the ALTO and access image elements by comparing the numeric part of the file name. No such matching was implemented at this stage though.

The classes for ALTO and access image files also diverged a bit due to this change: only access images take the location_xlink when initializing. Instead, all files know their page number.

Only inspecting the fileGrp for access images means that we no longer have verification that the METS does not contain surprising file group USE and ID pairs that we should process. The earlier DAG runs have not uncovered such file groups though.

Against all best practices, the file naming convention was renewed at the same time, so that all files have a name that consists of the page number (padded with leading zeroes so that it is 5 digits long) and a file type extension.