### PR TITLE
KP-7310 Proper configuration when provisioning dev/prod

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -60,7 +60,7 @@ ansible-playbook harvesterPouta.yml -i inventories/dev --tags dag-update --extra
 
 ## Creating multiple dev instances
 
-If more than one development instance is in use simultaneously, they must be configured so that they won't overwrite each other's data in Puhti. This involves setting the following variables to non-default values (see production inventory for one way of doing this):
+If more than one development instance is in use simultaneously, they must be configured so that they won't overwrite each other's data in Puhti. This involves setting the following variables to non-default values (see production and dev inventories for one way of doing this):
 - `pipeline_extra_bin_dir`
 - `pipeline_output_dir`
 - `pipeline_tmpdir_root`

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -66,3 +66,10 @@ If more than one development instance is in use simultaneously, they must be con
 - `pipeline_tmpdir_root`
 - `pipeline_extra_bin_dir`
 - `restic_repository_bucket`
+
+
+### Publishing a Restic repository
+
+If a newly created repository needs to be made accessible without AWS access key and key id (e.g. for demo or testing purposes), it needs to be published. This can be done in [Pouta web interface](https://pouta.csc.fi) by under _Object storage_ > _Containers_ by choosing the correct bucket and ticking the box _Public access_. This allows accessing the repository e.g. from a local laptop that has Restic installed.
+
+Allowing truly public read-only access would also require manually adding a second, shareable, password for the repo using `restic key` command.

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -55,3 +55,11 @@ If you have a specific branch/tag/SHA-1 you wish to use, you can provide that:
 ```
 ansible-playbook harvesterPouta.yml -i inventories/dev --tags dag-update --extra-vars "harvester_branch=[KP-yourbranch]"
 ```
+
+## Creating multiple dev instances
+
+If more than one development instance is in use simultaneously, they must be configured so that they won't overwrite each other's data in Puhti. This involves setting the following variables to non-default values (see production inventory for one way of doing this):
+- `pipeline_extra_bin_dir`
+- `pipeline_output_dir`
+- `pipeline_tmpdir_root`
+- `pipeline_extra_bin_dir`

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -37,7 +37,7 @@ $ source project_2006633-openrc.sh
 ansible-playbook -i inventories/dev harvesterPouta.yml --extra-vars initial_download=true
 ```
 
-Adjust `initial_download` as needed (default is false for safe reprovisioning of the production environment).
+Adjust `initial_download` as needed (default is false for safe reprovisioning of the production environment). This can also be edited in the Airflow web GUI under variables. NB: The variable will not automatically flip to `false` when a collection is downloaded, allowing e.g. repeated full download testing or downloading different small collections from dev instances.
 
 Have your `kielipouta` password and `Kielipankki-passwords` GPG key password at hand, they may need to be inputted during provisioning.
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -65,3 +65,4 @@ If more than one development instance is in use simultaneously, they must be con
 - `pipeline_output_dir`
 - `pipeline_tmpdir_root`
 - `pipeline_extra_bin_dir`
+- `restic_repository_bucket`

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -34,8 +34,10 @@ $ source project_2006633-openrc.sh
 ## Run ansible playbook
 
 ```
-ansible-playbook -i inventories/dev harvesterPouta.yml
+ansible-playbook -i inventories/dev harvesterPouta.yml --extra-vars initial_download=true
 ```
+
+Adjust `initial_download` as needed (default is false for safe reprovisioning of the production environment).
 
 Have your `kielipouta` password and `Kielipankki-passwords` GPG key password at hand, they may need to be inputted during provisioning.
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -61,7 +61,6 @@ ansible-playbook harvesterPouta.yml -i inventories/dev --tags dag-update --extra
 ## Creating multiple dev instances
 
 If more than one development instance is in use simultaneously, they must be configured so that they won't overwrite each other's data in Puhti. This involves setting the following variables to non-default values (see production and dev inventories for one way of doing this):
-- `pipeline_extra_bin_dir`
 - `pipeline_output_dir`
 - `pipeline_tmpdir_root`
 - `pipeline_extra_bin_dir`

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -22,6 +22,7 @@ airflow_lastname: "User"
 airflow_email: "ling-admin@listat.csc.fi"
 
 restic_repository: "s3:https://a3s.fi/nlf-harvester-versioning"
+pipeline_extra_bin_dir: "/projappl/project_2006633/local/bin"
 
 puhti_robot_user: "robot_2006633_puhti"
 puhti_robot_password: "{{ lookup('passwordstore', 'lb_passwords/airflow/robot_2006633_puhti') }}"

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -22,7 +22,6 @@ airflow_lastname: "User"
 airflow_email: "ling-admin@listat.csc.fi"
 
 restic_repository: "s3:https://a3s.fi/nlf-harvester-versioning"
-pipeline_extra_bin_dir: "/projappl/project_2006633/local/bin"
 
 puhti_robot_user: "robot_2006633_puhti"
 puhti_robot_password: "{{ lookup('passwordstore', 'lb_passwords/airflow/robot_2006633_puhti') }}"

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -21,7 +21,7 @@ airflow_firstname: "Kielipankki"
 airflow_lastname: "User"
 airflow_email: "ling-admin@listat.csc.fi"
 
-restic_repository: "s3:https://a3s.fi/nlf-harvester-versioning"
+restic_repository: "s3:https://a3s.fi/{{ restic_repository_bucket }}"
 
 puhti_robot_user: "robot_2006633_puhti"
 puhti_robot_password: "{{ lookup('passwordstore', 'lb_passwords/airflow/robot_2006633_puhti') }}"

--- a/ansible/inventories/dev
+++ b/ansible/inventories/dev
@@ -3,11 +3,11 @@ all:
     localhost:
       ansible_connection: local
       ansible_python_interpreter: "{{ansible_playbook_python}}"
-      floating_ip: 86.50.229.214
+      floating_ip: 128.214.253.232
   children:
     airflow:
       hosts:
-        86.50.229.214:
+        128.214.253.232:
           ansible_user: ubuntu
           navbar_color: "#ff5800"
     puhti:

--- a/ansible/inventories/dev
+++ b/ansible/inventories/dev
@@ -20,5 +20,5 @@ all:
     harvested_collections:
       - id: col-861
         subset_size: 100000
-      - id: col-501
-        subset_size: 1000
+      - id: col-201
+        subset_size: 100

--- a/ansible/inventories/dev
+++ b/ansible/inventories/dev
@@ -17,3 +17,8 @@ all:
           ansible_password: "{{ puhti_robot_password }}"
   vars:
     pipeline_extra_bin_dir: "/projappl/{{ puhti_robot_user }}/local/bin/harvester-dev"
+    harvested_collections:
+      - id: col-861
+        subset_size: 100000
+      - id: col-501
+        subset_size: 1000

--- a/ansible/inventories/dev
+++ b/ansible/inventories/dev
@@ -15,3 +15,5 @@ all:
         puhti.csc.fi:
           ansible_user: "{{ puhti_robot_user }}"
           ansible_password: "{{ puhti_robot_password }}"
+  vars:
+    pipeline_extra_bin_dir: "/projappl/{{ puhti_robot_user }}/local/bin/harvester-dev"

--- a/ansible/inventories/dev
+++ b/ansible/inventories/dev
@@ -22,3 +22,4 @@ all:
         subset_size: 100000
       - id: col-201
         subset_size: 100
+    restic_repository_bucket: harvester-versioning-dev

--- a/ansible/inventories/dev
+++ b/ansible/inventories/dev
@@ -16,7 +16,7 @@ all:
           ansible_user: "{{ puhti_robot_user }}"
           ansible_password: "{{ puhti_robot_password }}"
   vars:
-    pipeline_extra_bin_dir: "/projappl/{{ puhti_robot_user }}/local/bin/harvester-dev"
+    pipeline_extra_bin_dir: "/projappl/project_2006633/local/bin/harvester-dev"
     harvested_collections:
       - id: col-861
         subset_size: 100000

--- a/ansible/inventories/prod
+++ b/ansible/inventories/prod
@@ -15,3 +15,7 @@ all:
         puhti.csc.fi:
           ansible_user: "{{ puhti_robot_user }}"
           ansible_password: "{{ puhti_robot_password }}"
+  vars:
+    pipeline_output_dir: "/scratch/project_2006633/nlf-harvester"
+    pipeline_tmpdir_root: "/local_scratch/{{ puhti_robot_user }}/harvester"
+    pipeline_extra_bin_dir: "/projappl/project_2006633/local/bin"

--- a/ansible/inventories/prod
+++ b/ansible/inventories/prod
@@ -19,3 +19,4 @@ all:
     pipeline_output_dir: "/scratch/project_2006633/nlf-harvester"
     pipeline_tmpdir_root: "/local_scratch/{{ puhti_robot_user }}/harvester"
     pipeline_extra_bin_dir: "/projappl/project_2006633/local/bin"
+    restic_repository_bucket: nlf-harvester-versioning

--- a/ansible/roles/harvester-setup/defaults/main.yml
+++ b/ansible/roles/harvester-setup/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 
 initial_download: "false"
+pipeline_task_retries: 1
 pipeline_output_dir: "/scratch/project_2006633/harvester-dev"
 pipeline_tmpdir_root: "/local_scratch/{{ puhti_robot_user }}/harvester-dev"
 pipeline_subset_split_dir: "/home/{{ ansible_user }}/subset_split"

--- a/ansible/roles/harvester-setup/defaults/main.yml
+++ b/ansible/roles/harvester-setup/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+
+initial_download: "false"
+pipeline_output_dir: "/scratch/project_2006633/harvester-dev"
+pipeline_tmpdir_root: "/local_scratch/{{ puhti_robot_user }}/harvester-dev"
+pipeline_subset_split_dir: "/home/{{ ansible_user }}/subset_split"
+pipeline_binding_list_dir: "/home/{{ ansible_user }}/binding_ids_all"

--- a/ansible/roles/harvester-setup/defaults/main.yml
+++ b/ansible/roles/harvester-setup/defaults/main.yml
@@ -5,3 +5,6 @@ pipeline_output_dir: "/scratch/project_2006633/harvester-dev"
 pipeline_tmpdir_root: "/local_scratch/{{ puhti_robot_user }}/harvester-dev"
 pipeline_subset_split_dir: "/home/{{ ansible_user }}/subset_split"
 pipeline_binding_list_dir: "/home/{{ ansible_user }}/binding_ids_all"
+harvested_collections:
+  - id: col-861
+    subset_size: 100000

--- a/ansible/roles/harvester-setup/tasks/main.yml
+++ b/ansible/roles/harvester-setup/tasks/main.yml
@@ -70,6 +70,19 @@
     src: restic_env.yaml.j2
     dest: /home/ubuntu/restic_env.yaml
 
+- name: Copy Airflow variable file to remote
+  template:
+    src: airflow_variables.json.j2
+    dest: /home/ubuntu/airflow_variables.json
+  tags:
+    - dag-update
+
+- name: Register Airflow variables
+  ansible.builtin.command:
+    cmd: airflow variables import /home/ubuntu/airflow_variables.json
+  tags:
+    - dag-update
+
 - name: Add private key for connecting to Puhti
   ansible.builtin.copy:
     dest: "{{ puhti_robot_ssh_key_path }}"

--- a/ansible/roles/harvester-setup/templates/airflow_variables.json.j2
+++ b/ansible/roles/harvester-setup/templates/airflow_variables.json.j2
@@ -1,11 +1,11 @@
 {
-  "initial_download": true,
+  "initial_download": {{ initial_download }},
   "path_config": {
-      "OUTPUT_DIR": "/scratch/project_2006633/nlf-harvester",
-      "TMPDIR_ROOT": "/local_scratch/robot_2006633_puhti/harvester",
-      "EXTRA_BIN_DIR": "/projappl/project_2006633/local/bin",
-      "SUBSET_SPLIT_DIR": "/home/ubuntu/subset_split/",
-      "BINDING_LIST_DIR": "/home/ubuntu/binding_ids_all"
+      "OUTPUT_DIR": "{{ pipeline_output_dir }}",
+      "TMPDIR_ROOT": "{{ pipeline_tmpdir_root }}",
+      "EXTRA_BIN_DIR": "{{ pipeline_extra_bin_dir }}",
+      "SUBSET_SPLIT_DIR": "{{ pipeline_subset_split_dir }}",
+      "BINDING_LIST_DIR": "{{ pipeline_binding_list_dir }}"
   },
   "collections": [
     {"id": "col-861", "subset_size": 100000}

--- a/ansible/roles/harvester-setup/templates/airflow_variables.json.j2
+++ b/ansible/roles/harvester-setup/templates/airflow_variables.json.j2
@@ -1,0 +1,13 @@
+{
+  "initial_download": true,
+  "path_config": {
+      "OUTPUT_DIR": "/scratch/project_2006633/nlf-harvester",
+      "TMPDIR_ROOT": "/local_scratch/robot_2006633_puhti/harvester",
+      "EXTRA_BIN_DIR": "/projappl/project_2006633/local/bin",
+      "SUBSET_SPLIT_DIR": "/home/ubuntu/subset_split/",
+      "BINDING_LIST_DIR": "/home/ubuntu/binding_ids_all"
+  },
+  "collections": [
+    {"id": "col-861", "subset_size": 100000}
+  ]
+}

--- a/ansible/roles/harvester-setup/templates/airflow_variables.json.j2
+++ b/ansible/roles/harvester-setup/templates/airflow_variables.json.j2
@@ -8,6 +8,15 @@
       "BINDING_LIST_DIR": "{{ pipeline_binding_list_dir }}"
   },
   "collections": [
-    {"id": "col-861", "subset_size": 100000}
+  {% for item in harvested_collections -%}
+    {
+      "id": "{{ item.id }}",
+      "subset_size": {{ item.subset_size }}
+    }
+    {%- if not loop.last -%}
+      ,
+    {% endif -%}
+  {% endfor %}
+
   ]
 }

--- a/ansible/roles/harvester-setup/templates/airflow_variables.json.j2
+++ b/ansible/roles/harvester-setup/templates/airflow_variables.json.j2
@@ -1,5 +1,6 @@
 {
   "initial_download": {{ initial_download }},
+  "retries": {{ pipeline_task_retries }},
   "path_config": {
       "OUTPUT_DIR": "{{ pipeline_output_dir }}",
       "TMPDIR_ROOT": "{{ pipeline_tmpdir_root }}",

--- a/ansible/roles/restic-script-to-puhti/tasks/main.yml
+++ b/ansible/roles/restic-script-to-puhti/tasks/main.yml
@@ -26,7 +26,6 @@
     - 'not "\"paths\":[" in snapshot_list.stdout'  # repo exists, snapshot data reported
     - not 'Is there a repository at the following location?' in snapshot_list.stderr  # no snapshot found
     - "not 'Fatal: unable to open config file: Stat: The specified bucket does not exist.' in snapshot_list.stderr"  # no bucket
-  tags: rscript
 
 - name: Create bucket for restic repository if not already present
   ansible.builtin.shell: |
@@ -37,7 +36,6 @@
     AWS_ACCESS_KEY_ID: "{{ lookup('passwordstore', 'lb_passwords/airflow/aws_access_key_id') }}"
     BUCKET_NAME: "{{ restic_repository_bucket }}"
   when: "'The specified bucket does not exist' in snapshot_list.stderr"
-  tags: rscript
 
 - name: Initiate a repository if not already present
   ansible.builtin.shell: |
@@ -50,4 +48,3 @@
     RESTIC_REPOSITORY: "{{ restic_repository }}"
     RESTIC_PASSWORD: "{{ lookup('passwordstore', 'lb_passwords/airflow/restic_password') }}"
   when: snapshot_list.rc != 0
-  tags: rscript

--- a/ansible/roles/restic-script-to-puhti/tasks/main.yml
+++ b/ansible/roles/restic-script-to-puhti/tasks/main.yml
@@ -1,4 +1,4 @@
 - name: Make sure that restic script exists in Puhti
   ansible.builtin.copy:
     src: ../files/create_snapshot.sh
-    dest: /projappl/project_2006633/local/bin/create_snapshot.sh
+    dest: "{{ pipeline_extra_bin_dir }}/create_snapshot.sh"

--- a/ansible/roles/restic-script-to-puhti/tasks/main.yml
+++ b/ansible/roles/restic-script-to-puhti/tasks/main.yml
@@ -1,3 +1,10 @@
+---
+
+- name: Create directory for restic script
+  ansible.builtin.file:
+    path: "{{ pipeline_extra_bin_dir }}"
+    state: directory
+
 - name: Make sure that restic script exists in Puhti
   ansible.builtin.copy:
     src: ../files/create_snapshot.sh

--- a/ansible/roles/restic-script-to-puhti/tasks/main.yml
+++ b/ansible/roles/restic-script-to-puhti/tasks/main.yml
@@ -9,3 +9,45 @@
   ansible.builtin.copy:
     src: ../files/create_snapshot.sh
     dest: "{{ pipeline_extra_bin_dir }}/create_snapshot.sh"
+
+- name: Check if the restic repository exists already
+  ansible.builtin.shell: |
+    module load allas
+    restic snapshots --no-lock --json
+  delegate_to: puhti
+  environment:
+    AWS_SECRET_ACCESS_KEY: "{{ lookup('passwordstore', 'lb_passwords/airflow/aws_secret_access_key') }}"
+    AWS_ACCESS_KEY_ID: "{{ lookup('passwordstore', 'lb_passwords/airflow/aws_access_key_id') }}"
+    RESTIC_REPOSITORY: "{{ restic_repository }}"
+    RESTIC_PASSWORD: "{{ lookup('passwordstore', 'lb_passwords/airflow/restic_password') }}"
+  register: snapshot_list
+  failed_when:  # Sanity check that fails the task if we get an unexpected output
+    - not snapshot_list.stdout == "[]"  # repo exists, no snapshots
+    - 'not "\"paths\":[" in snapshot_list.stdout'  # repo exists, snapshot data reported
+    - not 'Is there a repository at the following location?' in snapshot_list.stderr  # no snapshot found
+    - "not 'Fatal: unable to open config file: Stat: The specified bucket does not exist.' in snapshot_list.stderr"  # no bucket
+  tags: rscript
+
+- name: Create bucket for restic repository if not already present
+  ansible.builtin.shell: |
+    module load allas
+    s3cmd mb s3://$BUCKET_NAME --host=a3s.fi --host-bucket='%(bucket)s.a3s.fi'
+  environment:
+    AWS_SECRET_ACCESS_KEY: "{{ lookup('passwordstore', 'lb_passwords/airflow/aws_secret_access_key') }}"
+    AWS_ACCESS_KEY_ID: "{{ lookup('passwordstore', 'lb_passwords/airflow/aws_access_key_id') }}"
+    BUCKET_NAME: "{{ restic_repository_bucket }}"
+  when: "'The specified bucket does not exist' in snapshot_list.stderr"
+  tags: rscript
+
+- name: Initiate a repository if not already present
+  ansible.builtin.shell: |
+      module load allas
+      restic init
+  delegate_to: puhti
+  environment:
+    AWS_SECRET_ACCESS_KEY: "{{ lookup('passwordstore', 'lb_passwords/airflow/aws_secret_access_key') }}"
+    AWS_ACCESS_KEY_ID: "{{ lookup('passwordstore', 'lb_passwords/airflow/aws_access_key_id') }}"
+    RESTIC_REPOSITORY: "{{ restic_repository }}"
+    RESTIC_PASSWORD: "{{ lookup('passwordstore', 'lb_passwords/airflow/restic_password') }}"
+  when: snapshot_list.rc != 0
+  tags: rscript

--- a/pipeline/dags/download_collections.py
+++ b/pipeline/dags/download_collections.py
@@ -32,7 +32,7 @@ default_args = {
     "owner": "Kielipankki",
     "start_date": "2023-05-22",
     "retry_delay": timedelta(minutes=5),
-    "retries": 3,
+    "retries": Variable.get("retries"),
 }
 
 http_conn = BaseHook.get_connection(HTTP_CONN_ID)

--- a/pipeline/dags/fetch_binding_ids.py
+++ b/pipeline/dags/fetch_binding_ids.py
@@ -19,7 +19,7 @@ default_args = {
     "owner": "Kielipankki",
     "start_date": "2022-10-01",
     "retry_delay": timedelta(minutes=5),
-    "retries": 3,
+    "retries": Variable.get("retries"),
 }
 
 

--- a/pipeline/dags/fetch_binding_ids.py
+++ b/pipeline/dags/fetch_binding_ids.py
@@ -48,7 +48,7 @@ def fetch_bindings_dag():
         def save_ids_for_set(set_id):
 
             folder_path = Path(
-                Variable.get("path_dict", deserialize_json=True)["BINDING_LIST_DIR"]
+                Variable.get("path_config", deserialize_json=True)["BINDING_LIST_DIR"]
             ) / set_id.replace(":", "_")
 
             if not os.path.isdir(folder_path):

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -65,19 +65,19 @@ def download_set(
     api,
     ssh_conn_id,
     initial_download,
-    pathdict,
+    path_config,
 ):
-    bindings = utils.read_bindings(pathdict["BINDING_LIST_DIR"], set_id)
+    bindings = utils.read_bindings(path_config["BINDING_LIST_DIR"], set_id)
 
     prefixes = [str(i) for i in range(10, 20)] + [str(i) for i in range(2, 10)]
 
     if initial_download:
         subset_split = utils.assign_bindings_to_subsets(bindings, prefixes)
-        utils.save_subset_split(subset_split, pathdict["SUBSET_SPLIT_DIR"], set_id)
+        utils.save_subset_split(subset_split, path_config["SUBSET_SPLIT_DIR"], set_id)
 
     else:
         subset_split = utils.assign_update_bindings_to_subsets(
-            bindings, pathdict["SUBSET_SPLIT_DIR"] / f"{set_id}_subsets.json"
+            bindings, path_config["SUBSET_SPLIT_DIR"] / f"{set_id}_subsets.json"
         )
 
     subset_downloads = []
@@ -92,16 +92,16 @@ def download_set(
                 else:
                     subset_base_name = set_id
 
-                file_download_dir = pathdict["TMPDIR_ROOT"] / subset_base_name
+                file_download_dir = path_config["TMPDIR_ROOT"] / subset_base_name
                 target_path = (
-                    pathdict["OUTPUT_DIR"] / "targets" / (subset_base_name + ".zip")
+                    path_config["OUTPUT_DIR"] / "targets" / (subset_base_name + ".zip")
                 )
-                target_directory = pathdict["OUTPUT_DIR"] / "targets"
+                target_directory = path_config["OUTPUT_DIR"] / "targets"
                 intermediate_zip_directory = (
-                    pathdict["OUTPUT_DIR"] / "intermediate_zip" / subset_base_name
+                    path_config["OUTPUT_DIR"] / "intermediate_zip" / subset_base_name
                 )
                 published_zip_path = (
-                    pathdict["OUTPUT_DIR"] / "zip" / (subset_base_name + ".zip")
+                    path_config["OUTPUT_DIR"] / "zip" / (subset_base_name + ".zip")
                 )
 
                 prepare_download_location = PrepareDownloadLocationOperator(
@@ -131,7 +131,7 @@ def download_set(
                         task_id="download_binding_batch",
                         trigger_rule="none_skipped",
                         ssh_conn_id=ssh_conn_id,
-                        tmp_download_directory=pathdict["TMPDIR_ROOT"]
+                        tmp_download_directory=path_config["TMPDIR_ROOT"]
                         / subset_base_name,
                         intermediate_zip_directory=intermediate_zip_directory,
                         api=api,


### PR DESCRIPTION
Previously, we needed to manually adjust the DAGs in dev environments to avoid overwriting production data. Now the provisioning script should produce properly configured environments depending on the inventory. This covers the following aspects:
- Temporary files needed during creation of the published zips
- Published zips
- Restic backup creation script
- Restic bucket used for versioning

Some additional improvements were also done:
- Possibility to set `initial_download` when provisioning or later in the GUI
- Possibility to configure the number of retries (default was lowered to 1 as genuine network problems haven't seemed common)

Customizing the DAGs for different environments has now been done using [variables](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/variables.html). These are reasonably easy to set automatically and can be adjusted in the GUI too. As a downside, the variables are shared across all DAGs, meaning that if we e.g. had two collections we wanted to download, both their DAGs would read the same `initial_download`. This won't happen in production in the foreseeable future though, so this shouldn't be a major issue.