### PR TITLE
KP-6519 Deleted bindings

### DIFF
--- a/ansible/roles/harvester-setup/defaults/main.yml
+++ b/ansible/roles/harvester-setup/defaults/main.yml
@@ -6,6 +6,8 @@ pipeline_output_dir: "/scratch/project_2006633/harvester-dev"
 pipeline_tmpdir_root: "/local_scratch/{{ puhti_robot_user }}/harvester-dev"
 pipeline_subset_split_dir: "/home/{{ ansible_user }}/subset_split"
 pipeline_binding_list_dir: "/home/{{ ansible_user }}/binding_ids_all"
+pipeline_added_bindings_prefix: "binding_ids"
+pipeline_deleted_bindings_prefix: "deleted_binding_ids"
 harvested_collections:
   - id: col-861
     subset_size: 100000

--- a/ansible/roles/harvester-setup/templates/airflow_variables.json.j2
+++ b/ansible/roles/harvester-setup/templates/airflow_variables.json.j2
@@ -6,7 +6,9 @@
       "TMPDIR_ROOT": "{{ pipeline_tmpdir_root }}",
       "EXTRA_BIN_DIR": "{{ pipeline_extra_bin_dir }}",
       "SUBSET_SPLIT_DIR": "{{ pipeline_subset_split_dir }}",
-      "BINDING_LIST_DIR": "{{ pipeline_binding_list_dir }}"
+      "BINDING_LIST_DIR": "{{ pipeline_binding_list_dir }}",
+      "ADDED_BINDINGS_PREFIX": "{{ pipeline_added_bindings_prefix }}",
+      "DELETED_BINDINGS_PREFIX": "{{ pipeline_deleted_bindings_prefix }}"
   },
   "collections": [
   {% for item in harvested_collections -%}

--- a/harvester/pmh_interface.py
+++ b/harvester/pmh_interface.py
@@ -87,7 +87,7 @@ class PMH_API:
                 if deletion_time < threshold_time:
                     continue
 
-            yield identifier
+            yield f"https://digi.kansalliskirjasto.fi/sanomalehti/binding/{identifier.rsplit(':')[-1]}"
 
     def download_mets(self, dc_identifier, output_mets_file):
         """

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -106,6 +106,9 @@ def split_into_download_batches(bindings):
     Return a list of tuples, containing the batch itself and the batch index.
     """
     subset_size = len(bindings)
+    if subset_size == 0:
+        return [([], 0)]
+
     batch_size = calculate_batch_size(subset_size)
     batches = [bindings[i : i + batch_size] for i in range(0, subset_size, batch_size)]
     return list(zip(batches, range(len(batches))))

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -177,7 +177,7 @@ def subset_for_binding(dc_identifier, subset_split):
 
 
 def assign_update_bindings_to_subsets(
-    added_bindings, deleted_bindings, subset_split_file
+    added_bindings_dc_identifiers, deleted_bindings_dc_identifiers, subset_split_file
 ):
     """
     Assign an incoming list of new bindings into existing disk subsets
@@ -209,8 +209,8 @@ def assign_update_bindings_to_subsets(
         subset_split = json.load(json_file)
     existing_subsets = {}
     for identifiers, key_name in (
-        [added_bindings, "added"],
-        [deleted_bindings, "deleted"],
+        [added_bindings_dc_identifiers, "added"],
+        [deleted_bindings_dc_identifiers, "deleted"],
     ):
         for dc_identifier in identifiers:
             subset = subset_for_binding(dc_identifier, subset_split)

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -103,11 +103,11 @@ def calculate_batch_size(subset_size):
 def split_into_download_batches(bindings):
     """
     Split a subset into download batches.
-    Return a list of tuples, containing the batch itself and the batch index.
+
+    Return a list of tuples, containing the batch itself and the batch index. If there
+    are no bindings, returns None instead.
     """
     subset_size = len(bindings)
-    if subset_size == 0:
-        return [([], 0)]
 
     batch_size = calculate_batch_size(subset_size)
     batches = [bindings[i : i + batch_size] for i in range(0, subset_size, batch_size)]

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -104,8 +104,8 @@ def split_into_download_batches(bindings):
     """
     Split a subset into download batches.
 
-    Return a list of tuples, containing the batch itself and the batch index. If there
-    are no bindings, returns None instead.
+    Return a list of tuples, containing the batch itself and the batch index. Raises a
+    ValueError if given list of bindings is empty.
     """
     subset_size = len(bindings)
 

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -231,15 +231,16 @@ def read_bindings(binding_list_dir, set_id, binding_file_prefix):
     binding_ids_all/col-861/binding_ids_2025-06-12
     """
     try:
-        binding_id_dates = [
+        binding_list_dates = [
             datetime.strptime(fname.split("_")[-1], "%Y-%m-%d").date()
             for fname in os.listdir(binding_list_dir / set_id)
         ]
     except FileNotFoundError:
         raise FileNotFoundError(f"No binding ID file found for set {set_id}")
-    latest = max(binding_id_dates)
+    latest_list_date = max(binding_list_dates)
     with open(
-        binding_list_dir / set_id / f"{binding_file_prefix}_{str(latest)}", "r"
+        binding_list_dir / set_id / f"{binding_file_prefix}_{str(latest_list_date)}",
+        "r",
     ) as f:
         bindings = f.read().splitlines()
     return bindings

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -151,12 +151,13 @@ def assign_bindings_to_subsets(
 
     """
     subsets = {prefix: {"added": [], "deleted": []} for prefix in prefixes}
-    for dc_identifier in added_binding_dc_identifiers:
-        prefix = subset_for_binding(dc_identifier, prefixes)
-        subsets[prefix]["added"].append(dc_identifier)
-    for dc_identifier in deleted_binding_dc_identifiers:
-        prefix = subset_for_binding(dc_identifier, prefixes)
-        subsets[prefix]["deleted"].append(dc_identifier)
+    for identifiers, key_name in (
+        [added_binding_dc_identifiers, "added"],
+        [deleted_binding_dc_identifiers, "deleted"],
+    ):
+        for dc_identifier in identifiers:
+            prefix = subset_for_binding(dc_identifier, prefixes)
+            subsets[prefix][key_name].append(dc_identifier)
 
     return subsets
 
@@ -204,16 +205,15 @@ def assign_update_bindings_to_subsets(
     with open(subset_split_file, "r") as json_file:
         subset_split = json.load(json_file)
     existing_subsets = {}
-    for dc_identifier in added_bindings:
-        subset = subset_for_binding(dc_identifier, subset_split)
-        existing_subsets.setdefault(subset, {"added": [], "deleted": []})[
-            "added"
-        ].append(dc_identifier)
-    for dc_identifier in deleted_bindings:
-        subset = subset_for_binding(dc_identifier, subset_split)
-        existing_subsets.setdefault(subset, {"added": [], "deleted": []})[
-            "deleted"
-        ].append(dc_identifier)
+    for identifiers, key_name in (
+        [added_bindings, "added"],
+        [deleted_bindings, "deleted"],
+    ):
+        for dc_identifier in identifiers:
+            subset = subset_for_binding(dc_identifier, subset_split)
+            existing_subsets.setdefault(subset, {"added": [], "deleted": []})[
+                key_name
+            ].append(dc_identifier)
     return existing_subsets
 
 

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -234,6 +234,7 @@ def read_bindings(binding_list_dir, set_id, binding_file_prefix):
         binding_list_dates = [
             datetime.strptime(fname.split("_")[-1], "%Y-%m-%d").date()
             for fname in os.listdir(binding_list_dir / set_id)
+            if not fname.endswith(".swp")
         ]
     except FileNotFoundError:
         raise FileNotFoundError(f"No binding ID file found for set {set_id}")

--- a/harvester_cli.py
+++ b/harvester_cli.py
@@ -38,6 +38,28 @@ def binding_ids(set_id, url):
 
 
 @cli.command
+@click.argument("set_id")
+@click.option(
+    "--from-date",
+    default=None,
+    help="Earliest time of deletion to consider, e.g. 2026-01-28",
+)
+@click.option(
+    "--url",
+    default="https://digi.kansalliskirjasto.fi/interfaces/OAI-PMH",
+    help="URL of the OAI-PMH API to be used",
+)
+def deleted_binding_ids(set_id, from_date, url):
+    """
+    Fetch deleted binding IDs in the given set since a given date.
+    """
+    api = PMH_API(url)
+    ids = api.deleted_dc_identifiers(set_id, from_date=from_date)
+    for id_ in ids:
+        click.echo(id_)
+
+
+@cli.command
 @click.argument("mets_file_path")
 @click.argument(
     "collection_dc_identifier",

--- a/pipeline/dags/download_collections.py
+++ b/pipeline/dags/download_collections.py
@@ -62,6 +62,7 @@ for col in Variable.get("collections", deserialize_json=True):
             set_id=col["id"],
             binding_list_dir=path_config["BINDING_LIST_DIR"],
             http_conn_id=HTTP_CONN_ID,
+            path_config=path_config,
         ) >> [
             begin_download,
             cancel_pipeline,

--- a/pipeline/dags/fetch_binding_ids.py
+++ b/pipeline/dags/fetch_binding_ids.py
@@ -41,9 +41,9 @@ def fetch_bindings_dag():
     http_conn = BaseHook.get_connection(HTTP_CONN_ID)
     api = PMH_API(url=http_conn.host)
 
-    @task_group(group_id=f"save_bindings")
+    @task_group(group_id="save_bindings")
     def save_ids():
-        @task(task_id=f"save_ids_for_set")
+        @task(task_id="save_ids_for_set")
         def save_ids_for_set(set_id):
 
             folder_path = Path(

--- a/pipeline/dags/fetch_binding_ids.py
+++ b/pipeline/dags/fetch_binding_ids.py
@@ -54,17 +54,25 @@ def fetch_bindings_dag():
                 os.makedirs(folder_path)
             last_run = get_most_recent_dag_run(f"subset_download_{set_id}")
 
-            with open(f"{folder_path}/binding_ids_{date.today()}", "w") as file_obj:
+            with open(
+                f"{folder_path}/binding_ids_{date.today()}", "w"
+            ) as new_bindings_file, open(
+                "{folder_path}/deleted_binding_ids_{date.today()}", "w"
+            ) as deleted_bindings_file:
 
                 if Variable.get("initial_download", deserialize_json=True):
                     for item in api.dc_identifiers(set_id):
-                        file_obj.write(item + "\n")
+                        new_bindings_file.write(item + "\n")
+                    for item in api.deleted_dc_identifiers(set_id):
+                        deleted_bindings_file.write(item + "\n")
                 else:
                     try:
                         for item in api.dc_identifiers(set_id, from_date=last_run):
-                            file_obj.write(item + "\n")
+                            new_bindings_file.write(item + "\n")
                     except NoRecordsMatch:
                         print(f"No new bindings after date {last_run} for set {set_id}")
+                    for item in api.deleted_dc_identifiers(set_id, from_date=last_run):
+                        deleted_bindings_file.write(item + "\n")
 
         set_ids = [
             collection["id"]

--- a/pipeline/dags/fetch_binding_ids.py
+++ b/pipeline/dags/fetch_binding_ids.py
@@ -40,6 +40,7 @@ def fetch_bindings_dag():
 
     http_conn = BaseHook.get_connection(HTTP_CONN_ID)
     api = PMH_API(url=http_conn.host)
+    path_config = Variable.get("path_config", deserialize_json=True)
 
     @task_group(group_id="save_bindings")
     def save_ids():
@@ -61,7 +62,8 @@ def fetch_bindings_dag():
                 print(f"Fetching bindings for collection {set_id} since {last_run}")
 
             with open(
-                f"{folder_path}/binding_ids_{date.today()}", "w"
+                f"{folder_path}/{path_config['ADDED_BINDINGS_PREFIX']}_{date.today()}",
+                "w",
             ) as new_bindings_file:
 
                 try:
@@ -71,7 +73,12 @@ def fetch_bindings_dag():
                     print(f"No new bindings after date {last_run} for set {set_id}")
 
             with open(
-                f"{folder_path}/deleted_binding_ids_{date.today()}", "w"
+                (
+                    f"{folder_path}"
+                    "/"
+                    f"{path_config['DELETED_BINDINGS_PREFIX']}_{date.today()}"
+                ),
+                "w",
             ) as deleted_bindings_file:
                 for item in api.deleted_dc_identifiers(set_id, from_date=last_run):
                     deleted_bindings_file.write(item + "\n")

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -83,14 +83,19 @@ def download_set(
     prefixes = [str(i) for i in range(10, 20)] + [str(i) for i in range(2, 10)]
 
     if initial_download:
-        subset_split = utils.assign_bindings_to_subsets(added_bindings, [], prefixes)
+        subset_split = utils.assign_bindings_to_subsets(
+            added_bindings_dc_identifiers=added_bindings,
+            deleted_bindings_dc_identifiers=[],
+            prefixes=prefixes,
+        )
         utils.save_subset_split(subset_split, path_config["SUBSET_SPLIT_DIR"], set_id)
 
     else:
         subset_split = utils.assign_update_bindings_to_subsets(
-            added_bindings,
-            deleted_bindings,
-            path_config["SUBSET_SPLIT_DIR"] / f"{set_id}_subsets.json",
+            added_bindings_dc_identifiers=added_bindings,
+            deleted_bindings_dc_identifiers=deleted_bindings,
+            subset_split_file=path_config["SUBSET_SPLIT_DIR"]
+            / f"{set_id}_subsets.json",
         )
 
     subset_downloads = []

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -20,7 +20,7 @@ from operators.custom_operators import (
 
 
 @task.branch(task_id="check_if_download_should_begin")
-def check_if_download_should_begin(set_id, binding_list_dir, http_conn_id):
+def check_if_download_should_begin(set_id, binding_list_dir, http_conn_id, path_config):
     """
     Check if API is responding and if there are new bindings to download.
     If not, cancel pipeline.
@@ -41,9 +41,11 @@ def check_if_download_should_begin(set_id, binding_list_dir, http_conn_id):
     except RequestException:
         api_ok = False
 
-    added_bindings = utils.read_bindings(binding_list_dir, set_id, "binding_ids")
+    added_bindings = utils.read_bindings(
+        binding_list_dir, set_id, path_config["ADDED_BINDINGS_PREFIX"]
+    )
     deleted_bindings = utils.read_bindings(
-        binding_list_dir, set_id, "deleted_binding_ids"
+        binding_list_dir, set_id, path_config["DELETED_BINDINGS_PREFIX"]
     )
 
     if not added_bindings and not deleted_bindings:
@@ -72,10 +74,10 @@ def download_set(
     path_config,
 ):
     added_bindings = utils.read_bindings(
-        path_config["BINDING_LIST_DIR"], set_id, "binding_ids"
+        path_config["BINDING_LIST_DIR"], set_id, path_config["ADDED_BINDINGS_PREFIX"]
     )
     deleted_bindings = utils.read_bindings(
-        path_config["BINDING_LIST_DIR"], set_id, "deleted_binding_ids"
+        path_config["BINDING_LIST_DIR"], set_id, path_config["DELETED_BINDINGS_PREFIX"]
     )
 
     prefixes = [str(i) for i in range(10, 20)] + [str(i) for i in range(2, 10)]

--- a/pipeline/plugins/includes/tasks.py
+++ b/pipeline/plugins/includes/tasks.py
@@ -41,10 +41,13 @@ def check_if_download_should_begin(set_id, binding_list_dir, http_conn_id):
     except RequestException:
         api_ok = False
 
-    bindings = utils.read_bindings(binding_list_dir, set_id, "binding_ids")
+    added_bindings = utils.read_bindings(binding_list_dir, set_id, "binding_ids")
+    deleted_bindings = utils.read_bindings(
+        binding_list_dir, set_id, "deleted_binding_ids"
+    )
 
-    if not bindings:
-        print("No new bindings after previous download.")
+    if not added_bindings and not deleted_bindings:
+        print("No new or deleted bindings after previous download.")
         return "cancel_pipeline"
     if not api_ok:
         dag_instance = newest_dag_run()

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -357,10 +357,11 @@ class PuhtiSshOperator(BaseOperator):
 
 class CreateTargetOperator(PuhtiSshOperator):
     """
-    Create a final distribution target of the given source data.
+    Merge intermediate zips into a single distribution target.
 
     The target file is first created/updated in target_path. If everything
-    is successful, it's finally moved to the final location in the publish_to_users task.
+    is successful, it can be processed further and finally moved to the final location
+    in the publish_to_users task.
 
     :param ssh_conn_id: SSH connection id
     :param data_source: Path to the directory that contains the intermediate .zip files

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -419,6 +419,10 @@ class RemoveDeletedBindingsOperator(PuhtiSshOperator):
         ]
 
     def execute(self, context):
+        if not self.deleted_binding_identifiers:
+            self.log.info(f"No bindings to delete from {self.zip_path}")
+            return
+
         ssh_hook = SSHHook(ssh_conn_id=self.ssh_conn_id)
 
         self.log.info(f"::group::Removing the following bindings from {self.zip_path}")

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -513,7 +513,7 @@ class RemoveDeletedBindingsOperator(PuhtiSshOperator):
 
             self.run_in_login_shell(
                 ssh_client,
-                f'zip -d {self.zip_path} {" ".join(empty_dirs)}',
+                f'zip -d {zip_path} {" ".join(empty_dirs)}',
                 modules="libzip",
             )
 
@@ -526,13 +526,17 @@ class RemoveDeletedBindingsOperator(PuhtiSshOperator):
 
         ssh_hook = SSHHook(ssh_conn_id=self.ssh_conn_id)
         with ssh_hook.get_conn() as ssh_client:
-            ssh_client.exec_command(f"cp {self.zip_path} {temp_zip_path}")
+            self.ssh_execute_and_raise(
+                ssh_client, f"cp {self.zip_path} {temp_zip_path}"
+            )
 
             self.delete_bindings(ssh_client, temp_zip_path)
 
             self.delete_empty_directories(ssh_client, temp_zip_path)
 
-            ssh_client.exec_command(f"mv {temp_zip_path} {self.zip_path}")
+            self.ssh_execute_and_raise(
+                ssh_client, f"mv {temp_zip_path} {self.zip_path}"
+            )
 
         self.log.info("Deletion complete")
 

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -175,9 +175,6 @@ class StowBindingBatchOperator(BaseOperator):
             sftp_client = ssh_client.open_sftp()
             batch, batch_num = self.batch_with_index
 
-            if not batch:
-                self.log.info("No bindings to download")
-
             batch_root = self.tmp_download_directory / f"batch_{batch_num}"
             for dc_identifier in batch:
                 binding_id = utils.binding_id_from_dc(dc_identifier)

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -173,6 +173,10 @@ class StowBindingBatchOperator(BaseOperator):
         with ssh_hook.get_conn() as ssh_client:
             sftp_client = ssh_client.open_sftp()
             batch, batch_num = self.batch_with_index
+
+            if not batch:
+                self.log.info("No bindings to download")
+
             batch_root = self.tmp_download_directory / f"batch_{batch_num}"
             for dc_identifier in batch:
                 binding_id = utils.binding_id_from_dc(dc_identifier)

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -404,7 +404,12 @@ class CreateTargetOperator(PuhtiSshOperator):
 
 
 class RemoveDeletedBindingsOperator(PuhtiSshOperator):
-    """ """
+    """
+    Operatof for deleting files from our data set when they have been deleted at NLF.
+
+    This does not affect old versions of the data set, but the deleted files will not be
+    included in new zips any more.
+    """
 
     def __init__(
         self,

--- a/pipeline/plugins/operators/custom_operators.py
+++ b/pipeline/plugins/operators/custom_operators.py
@@ -469,9 +469,3 @@ class ShellCommandError(Exception):
         )
 
         super().__init__(message)
-
-
-class DownloadBatchError(Exception):
-    """
-    Error raised when an error occurs during the downloading and storing of a download batch
-    """

--- a/tests/harvester/test_utils.py
+++ b/tests/harvester/test_utils.py
@@ -168,6 +168,37 @@ def test_assign_update_bindings_to_subsets():
     assert small_subset_split[""]["added"] == bindings
 
 
+def test_assign_update_bindings_to_subsets_add_and_del():
+    """
+    Test that added and deleted bindings go to their own lists.
+    """
+    added = [
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/4463",
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/4468",
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/4469",
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/4470",
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/4472",
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/4479",
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/4480",
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/4481",
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/4482",
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/4483",
+    ]
+    deleted = [
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/4464",
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/4465",
+    ]
+    subset_split = utils.assign_update_bindings_to_subsets(
+        added, deleted, "tests/data/subset_split.json"
+    )
+    assert len(subset_split["4"]["added"]) == 10
+    assert len(subset_split["4"]["deleted"]) == 2
+    assert (
+        "https://digi.kansalliskirjasto.fi/sanomalehti/binding/4464"
+        in subset_split["4"]["deleted"]
+    )
+
+
 def test_read_bindings(tmpdir):
     """
     Test that a list of bindings is read from file correctly.


### PR DESCRIPTION
Deleted records can be listed based on collection and start of a date range.

The records are parsed from
https://digi.kansalliskirjasto.fi/interfaces/OAI-PMH?verb=ListRecords&metadataPrefix=oai_dc&set=deleted by filtering by collection and date instead of using searches such as https://digi.kansalliskirjasto.fi/interfaces/OAI-PMH?verb=ListIdentifiers&metadataPrefix=oai_dc&set=col-501&from=2025-03-01 and filtering for `status="deleted"`. This is done because the latter does not always include all records present in the former. For example th e latter says `<error code="noRecordsMatch">No records found with the given parameters.</error>` at the time of writing, while the former clearly lists
```
<record>
  <header status="deleted">
    <identifier>oai:digi.kansalliskirjasto.fi:3002584</identifier>
    <datestamp>2025-03-24T07:53:20Z</datestamp>
    <setSpec>col-501</setSpec>
    <setSpec>col-501:col-381</setSpec>
    <setSpec>col-501:col-381:col-480</setSpec>
    <setSpec>col-901</setSpec>
  </header>
</record>
```
whose datestamp falls within the defined range in latter search.

The Airflow pipeline required some renovating, because it is possible for a single subset to have either both deletions and additions, deletions but no additions, or additions but no deletions, and the generated tasks should reflect that. There's also a bit of other refactoring, e.g. extracting a parent class to hold shared "run a command on Puhti" type functionality to prevent the same wizardry having to be repeated in multiple operators.