### PR TITLE
KP-9953 Fix reset failing if there's no s3cmd config file

### DIFF
--- a/ansible/reset.yml
+++ b/ansible/reset.yml
@@ -22,7 +22,7 @@
     - name: Delete and recreate the bucket + repo in Allas
       ansible.builtin.shell: |
         module load allas
-        s3cmd del --recursive --force s3://harvester-versioning-dev
+        s3cmd del --recursive --force s3://harvester-versioning-dev --host=a3s.fi --host-bucket='%(bucket)s.a3s.fi'
         s3cmd mb s3://harvester-versioning-dev --host=a3s.fi --host-bucket='%(bucket)s.a3s.fi'
         restic init
       environment:


### PR DESCRIPTION
Without providing the host and host bucket, s3cmd defaults to Amazon if there is no config file available, so the deletion command naturally fails. Including the necssary parameters in both means that the deletion should not fail any more.