### PR TITLE
9766 rm "\n" reference

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -33,7 +33,7 @@ $ source project_2006633-openrc.sh
 
 ## Add robot SSH key to keyring
 
-Some of the actions on Puhti must be carried out as the robot user when provisioning. To enable this, you must get the corresponding SSH key (`lb_passwords/airflow/private-key-robot_2006633_puhti`) and its password (`lb_passwords/airflow/private-key-password-robot_2006633_puhti`) from the password store. Note the newlines marked as `\n` in the key: replace those with newlines when writing it to a file.
+Some of the actions on Puhti must be carried out as the robot user when provisioning. To enable this, you must get the corresponding SSH key (`lb_passwords/airflow/private-key-robot_2006633_puhti`) and its password (`lb_passwords/airflow/private-key-password-robot_2006633_puhti`) from the password store.
 
 ## Run ansible playbook
 


### PR DESCRIPTION
Removing "\n" reference, since key is now stored in pass using "--multiline" option