### PR TITLE
KP-11598 Add links to Roihu docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,13 +30,13 @@ At the moment, the harvesting does not automatically produce a list of files tha
 ## Accessing the dataset
 
 > [!NOTE]
-> The national supercomputer hardware at CSC is being upgraded: this documentation assumes you are using the dataset on [Roihu](https://docs.csc.fi/computing/systems-roihu/). It is currently in pilot use: if you still need to access the data set on Puhti, see [Puhti era documentation](https://github.com/CSCfi/kielipankki-nlf-harvester/tree/c9942c83dc78d57f1eb5d86432085f8f9f61ee76/docs). NB: Puhti computing services will be discontinued one month after Roihu general availability, and Puhti storage services (including this dataset) in August 2026. The data set on Puhti has ceased to update: the newest versions of dataset are available on Roihu and Allas.
+> The national supercomputer hardware at CSC is being upgraded: this documentation assumes you are using the dataset on [Roihu](https://docs.csc.fi/computing/systems-roihu/). Puhti is being decommissioned: computing services will be shut down on July 31st 2026 at 12:00 EEST and storage and login nodes on October 15th 2026 at 12:00 EEST. If you still need to access the data set on Puhti, see [Puhti era documentation](https://github.com/CSCfi/kielipankki-nlf-harvester/tree/c9942c83dc78d57f1eb5d86432085f8f9f61ee76/docs). NB: The data set on Puhti has ceased to update: the newest versions of dataset are available on Roihu and Allas.
 
 ### The newest version on Roihu
 
 For immediate access on the shared file system, the newest dataset is kept in the directory `/scratch/project_2006633/nlf-harvester/zip/`. That directory should be accessible to all users on Roihu.
 
-The [recommended way](https://docs.csc.fi/computing/disk/) to process the data on Roihu is to use a suitable compute node with a NVMe storage and extract parts of the dataset to the NVMe. The default quota can be accessed under `$TMPDIR`. The default quotas on shared nodes are fairly small, but full node reservations have more sizeable quotas and it is also possible to request disaggregated storage to be mounted on your node. See docs.csc.fi for details.
+The recommended way to process the data on Roihu is to use a suitable compute node with [temporary NVMe storage](https://docs.csc.fi/computing/roihu-disk/#temporary-local-disk-areas) and extract parts of the dataset to the NVMe. The default quota can be accessed under `$TMPDIR`. The default quotas on shared nodes are fairly small, but full node reservations have more sizeable quotas and it is also possible to request disaggregated storage to be mounted on your node.
 
 For example, the following command will extract binding `1416885` into `$TMPDIR`:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ The following will extract all metadata files:
 
 The resulting target directories will have segmented paths, like `1/16/163/1631/16318/16318/mets/16318_METS.xml`, and you can extract multiple times with different filters into the same target directory.
 
-For more advanced searching and extracting, consider extracting the metadata files as above, and using them to generate a list of binding IDs of interest. See our [example](https://github.com/CSCfi/kielipankki-nlf-harvester/blob/main/docs/apptainer/filter.py) of parsing and matching, and using either `unzip` or eg. Python's [zipfile](https://docs.python.org/3/library/zipfile.html) library for extracting the files you want.
+For more advanced searching and extracting, consider extracting the metadata files as above, and using them to generate a list of binding IDs of interest. See our [example](examples/filter.py) of parsing and matching, and using either `unzip` or eg. Python's [zipfile](https://docs.python.org/3/library/zipfile.html) library for extracting the files you want.
 
 > [!WARNING]
 > The dataset is currently updated once a month, at midnight on the first day of every month. This means that the dataset can change while your computations are in progress, which can lead to your analysis crashing or producing inconsistent results.

--- a/docs/examples/filter.py
+++ b/docs/examples/filter.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import os
+from lxml import etree
+import argparse
+import datetime
+
+
+def _date_formatter(s):
+    try:
+        return datetime.datetime.strptime(s, "%d.%m.%Y")
+    except ValueError:
+        return datetime.datetime.strptime(s, "%Y")
+
+
+def filter_dir_and_print(args):
+    for issue in os.listdir(args.collection_dir):
+        # We assume that every issue has a mets and alto directory
+        mets = etree.parse(
+            os.path.join(args.collection_dir, issue, "mets", f"{issue}_METS.xml")
+        )
+        namespaces = mets.getroot().nsmap
+        if None in namespaces:
+            # lxml doesn't support the empty namespace
+            namespaces["_"] = namespaces[None]
+            namespaces.pop(None)
+        date_issued = mets.xpath("//MODS:dateIssued", namespaces=namespaces)
+        if len(date_issued) == 0:
+            # We failed to find the date
+            continue
+        date_issued = date_issued[0].text.strip()
+        try:
+            date_issued = _date_formatter(date_issued)
+        except ValueError:
+            # We failed to parse the date
+            continue
+        # Now we can check against our conditions!
+        if args.start_date and date_issued < args.start_date:
+            continue
+        if args.end_date and date_issued > args.end_date:
+            continue
+        print(os.path.join(args.collection_dir, issue))
+
+
+if __name__ == "__main__":
+    argparser = argparse.ArgumentParser(
+        description="Generate a list of directories for a NLF subcollection"
+    )
+    argparser.add_argument("collection_dir")
+    argparser.add_argument("--start-date", action="store", type=_date_formatter)
+    argparser.add_argument("--end-date", action="store", type=_date_formatter)
+    args = argparser.parse_args()
+    filter_dir_and_print(args)

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -26,7 +26,7 @@ List snapshots:
 $ restic snapshots --no-lock
 ```
 
-Restore a single file from a specific snapshot into a [fast temporary disk](https://docs.csc.fi/computing/disk/#temporary-local-disk-areas) on Roihu:
+Restore a single file from a specific snapshot into a [fast temporary disk](https://docs.csc.fi/computing/roihu-disk/#temporary-local-disk-areas) on Roihu:
 ```
 $ restic restore 6fd4a7e4 -i col-861_16.zip -t $TMPDIR/example-directory/ --no-lock
 ```
@@ -238,7 +238,7 @@ Summary: Restored 5 / 1 files/dirs (3.866 GiB / 3.866 GiB) in 30:42
 ```
 
 > [!TIP]
-> On CSC HPC environments, you have two options for saving the data: [scratch](https://docs.csc.fi/computing/disk/#scratch-directory) and [temporary disk](https://docs.csc.fi/computing/disk/#temporary-local-disk-areas). Reading and writing from scratch (e.g. `/scratch/project_1234`) is slower but more quota is available. Reading from `$TMPDIR`, on the other hand, is fast, but storage space is more limited, and as the name suggests, the temporary directories will be purged after a while. See e.g. [Using CSC environment efficiently course material on disk areas](https://csc-training.github.io/csc-env-eff/#3-disk-areas) for more information.
+> On CSC HPC environments, you have two options for saving the data: [scratch](https://docs.csc.fi/computing/roihu-disk/#scratch-directory) and [temporary disk](https://docs.csc.fi/computing/roihu-disk#temporary-local-disk-areas). Reading and writing from scratch (e.g. `/scratch/project_1234`) is slower but more quota is available. Reading from `$TMPDIR`, on the other hand, is fast, but storage space is more limited, and as the name suggests, the temporary directories will be purged after a while. See e.g. [Using CSC environment efficiently course material on disk areas](https://csc-training.github.io/csc-env-eff/#3-disk-areas) for more information.
 
 ## Extracting the whole backup
 


### PR DESCRIPTION
Now that Roihu docs have been published, we can link to them.

Also noticed that deleting the apptainer docs broke one link. We don't really want to bring back the apptainer stuff, as that isn't a reasonable way to work with the data as it's stored nowadays, but the example python script could be useful, so I brought it back into a more generic directory.